### PR TITLE
With it as-is, I get 'can only concatenate list (not tuple) to list'

### DIFF
--- a/minihack/base.py
+++ b/minihack/base.py
@@ -222,9 +222,9 @@ class MiniHack(NetHackStaircase):
             self._glyph_mapper = GlyphMapper()
             if "pixel_crop" in self._minihack_obs_keys:
                 # Make sure glyphs_crop is there
-                self._minihack_obs_keys = self._minihack_obs_keys + [
+                self._minihack_obs_keys = tuple(self._minihack_obs_keys) + (
                     "glyphs_crop",
-                ]
+                )
 
         self.reward_manager = reward_manager
         if self.reward_manager is not None:


### PR DESCRIPTION
I can't currently run the fb-internal minihack due to this bug. Here's the obvious fix; if there's one that's more suitable, let me know.

Basically what happened here was that when I switched from the public minihack to the fb internal one, I started getting this concat issue. I'm not 100% sure what changed, but the basic issue is that before, a list was acceptable as inputs to the observation keys, but now it isn't. By casting to the consistent type, both should be acceptable.