### PR TITLE
Being able to save gifs when evaluating pre-trained agents

### DIFF
--- a/docs/agents/torchbeast.md
+++ b/docs/agents/torchbeast.md
@@ -50,16 +50,17 @@ For navigation tasks, the default parameters are already set. For skill acquisit
 
 The learning curves for all of our polybeast experiments can be accessed in our [Weights&Biases repository](https://wandb.ai/minihack).
 
-<!---
 ## Evaluate and Watch
 
 The following script allows to evaluate the performance of a model pre-trained with polybeast:
 
 ```bash
-# Watch the learned behaviour step-by-step
-python3 -m minihack.agent.polybeast.evaluate --env MiniHack-Room-5x5-v0 -c /path/to/checkpoint/directory/ --watch
+# Watch the learned behaviour step-by-step in the terminal
+python3 -m minihack.agent.polybeast.evaluate --env MiniHack-Room-5x5-v0 -c /path/to/checkpoint/directory --watch
 
-# Evaluate the pre-trained model for 5 episodes and save the ttyrecordings in minihack_data/
-python3 -m minihack.agent.polybeast.evaluate --env MiniHack-Room-5x5-v0 -c /path/to/checkpoint/directory/ --savedir minihack_data/ -n 5 --no-watch
+# Evaluate the pre-trained model for 1 episode and save the replay as a GIF file
+python3 -m minihack.agent.polybeast.evaluate --env MiniHack-Room-5x5-v0 -c /path/to/checkpoint/directory -n 1 --no-watch --save_gif --gif_path replay.gif
+
+# Print all options of the evaluation script
+python3 -m minihack.agent.polybeast.evaluate --help
 ```
--->

--- a/minihack/agent/polybeast/evaluate.py
+++ b/minihack/agent/polybeast/evaluate.py
@@ -154,9 +154,10 @@ def eval(
 
     if save_gif:
         # Make the GIF and delete the temporary directory
-        png_paths = os.path.join(tmpdir, "e_*_s_*.png")
+        png_files = glob.glob(os.path.join(tmpdir, "e_*_s_*.png"))
+        png_files.sort(key=os.path.getmtime)
 
-        img, *imgs = [PIL.Image.open(f) for f in sorted(glob.glob(png_paths))]
+        img, *imgs = [PIL.Image.open(f) for f in png_files]
         img.save(
             fp=gif_path,
             format="GIF",

--- a/minihack/envs/mazewalk.py
+++ b/minihack/envs/mazewalk.py
@@ -68,7 +68,7 @@ registration.register(
     entry_point="minihack.envs.mazewalk:MiniHackMazeWalk9x9",
 )
 registration.register(
-    id="MiniHack-MazeWalk-Premapped-9x9-v0",
+    id="MiniHack-MazeWalk-Mapped-9x9-v0",
     entry_point="minihack.envs.mazewalk:MiniHackMazeWalk9x9Premapped",
 )
 registration.register(
@@ -76,7 +76,7 @@ registration.register(
     entry_point="minihack.envs.mazewalk:MiniHackMazeWalk15x15",
 )
 registration.register(
-    id="MiniHack-MazeWalk-Premapped-15x15-v0",
+    id="MiniHack-MazeWalk-Mapped-15x15-v0",
     entry_point="minihack.envs.mazewalk:MiniHackMazeWalk15x15Premapped",
 )
 registration.register(
@@ -84,6 +84,6 @@ registration.register(
     entry_point="minihack.envs.mazewalk:MiniHackMazeWalk45x19",
 )
 registration.register(
-    id="MiniHack-MazeWalk-Premapped-45x19-v0",
+    id="MiniHack-MazeWalk-Mapped-45x19-v0",
     entry_point="minihack.envs.mazewalk:MiniHackMazeWalk45x19Premapped",
 )

--- a/minihack/scripts/play.py
+++ b/minihack/scripts/play.py
@@ -238,8 +238,8 @@ def main():
         "-e",
         "--env",
         type=str,
-        default="NetHackScore-v0",
-        help="Gym environment spec. Defaults to 'NetHackStaircase-v0'.",
+        default="MiniHack-Room-Random-5x5-v0",
+        help="Gym environment spec. Defaults to 'MiniHack-Room-Random-5x5-v0'.",
     )
     parser.add_argument(
         "-n",

--- a/minihack/scripts/play.py
+++ b/minihack/scripts/play.py
@@ -16,6 +16,10 @@ import gym
 import nle  # noqa: F401
 import minihack  # noqa: F401
 from nle import nethack
+import tempfile
+import shutil
+import glob
+import PIL.Image
 
 
 _ACTIONS = tuple(
@@ -72,7 +76,18 @@ def get_action(env, action_mode, is_raw_env):
 
 
 def play(
-    env, mode, ngames, max_steps, seeds, savedir, no_render, render_mode, debug
+    env,
+    mode,
+    ngames,
+    max_steps,
+    seeds,
+    savedir,
+    no_render,
+    render_mode,
+    debug,
+    save_gif,
+    gif_path,
+    gif_duration,
 ):
     env_name = env
     is_raw_env = env_name == "raw"
@@ -85,7 +100,17 @@ def play(
             ttyrec = "/dev/null"
         env = nethack.Nethack(ttyrec=ttyrec)
     else:
-        env = gym.make(env_name, savedir=savedir, max_episode_steps=max_steps)
+        env_kwargs = dict(
+            savedir=savedir,
+            max_episode_steps=max_steps,
+        )
+        if save_gif:
+            env_kwargs["observation_keys"] = ("pixel_crop",)
+
+        env = gym.make(
+            env_name,
+            **env_kwargs,
+        )
         if seeds is not None:
             env.seed(seeds)
         if not no_render:
@@ -103,6 +128,11 @@ def play(
 
     total_start_time = timeit.default_timer()
     start_time = total_start_time
+
+    if save_gif:
+        # Create a tmp directory for individual screenshots
+        tmpdir = tempfile.mkdtemp()
+
     while True:
         if not no_render:
             if not is_raw_env:
@@ -118,6 +148,10 @@ def play(
                 for line in chars:
                     print(line.tobytes().decode("utf-8"))
                 print(blstats)
+
+        if save_gif:
+            obs_image = PIL.Image.fromarray(obs["pixel_crop"])
+            obs_image.save(os.path.join(tmpdir, f"e_{episodes}_s_{steps}.png"))
 
         action = get_action(env, mode, is_raw_env)
         if action is None:
@@ -158,6 +192,24 @@ def play(
         if episodes == ngames:
             break
         env.reset()
+
+    if save_gif:
+        # Make the GIF and delete the temporary directory
+        png_files = glob.glob(os.path.join(tmpdir, "e_*_s_*.png"))
+        png_files.sort(key=os.path.getmtime)
+
+        img, *imgs = [PIL.Image.open(f) for f in png_files]
+        img.save(
+            fp=gif_path,
+            format="GIF",
+            append_images=imgs,
+            save_all=True,
+            duration=gif_duration,
+            loop=0,
+        )
+        shutil.rmtree(tmpdir)
+
+        print("Saving replay GIF at {}".format(os.path.abspath(gif_path)))
     env.close()
     print(
         "Finished after %i episodes and %f seconds. Mean sps: %f"
@@ -224,6 +276,31 @@ def main():
         default="human",
         choices=["human", "full", "ansi"],
         help="Render mode. Defaults to 'human'.",
+    )
+    parser.add_argument(
+        "--save_gif",
+        dest="save_gif",
+        action="store_true",
+        help="Saving a GIF replay of the evaluated episodes.",
+    )
+    parser.add_argument(
+        "--no-save_gif",
+        dest="save_gif",
+        action="store_false",
+        help="Do not save GIF.",
+    )
+    parser.set_defaults(save_gif=False)
+    parser.add_argument(
+        "--gif_path",
+        type=str,
+        default="replay.gif",
+        help="Where to save the produced GIF file.",
+    )
+    parser.add_argument(
+        "--gif_duration",
+        type=int,
+        default=300,
+        help="The duration of each gif image.",
     )
     flags = parser.parse_args()
 


### PR DESCRIPTION
This PR adds additional command line arguments to minihack.agent.torchbeast.evaluate and minihack.script.play scrips to save the agent-centred gifs with pixel-based tiles.