### PR TITLE
Supporting gym version 0.21.0

### DIFF
--- a/minihack/base.py
+++ b/minihack/base.py
@@ -9,7 +9,7 @@ import gym
 import numpy as np
 import pkg_resources
 from nle import _pynethack, nethack
-from nle.nethack.nethack import SCREEN_DESCRIPTIONS_SHAPE
+from nle.nethack.nethack import SCREEN_DESCRIPTIONS_SHAPE, OBSERVATION_DESC
 from nle.env.base import FULL_ACTIONS, NLE_SPACE_ITEMS
 from nle.env.tasks import NetHackStaircase
 from minihack.wiki import NetHackWiki
@@ -50,28 +50,46 @@ MH_NETHACKOPTIONS = (
 
 MINIHACK_SPACE_FUNCS = {
     "glyphs_crop": lambda x, y: gym.spaces.Box(
-        low=0, high=nethack.MAX_GLYPH, shape=(x, y), dtype=np.uint16
+        low=0,
+        high=nethack.MAX_GLYPH,
+        shape=(x, y),
+        dtype=OBSERVATION_DESC["glyphs"]["dtype"],
     ),
     "chars_crop": lambda x, y: gym.spaces.Box(
-        low=0, high=255, shape=(x, y), dtype=np.uint8
+        low=0,
+        high=255,
+        shape=(x, y),
+        dtype=OBSERVATION_DESC["chars"]["dtype"],
     ),
     "colors_crop": lambda x, y: gym.spaces.Box(
-        low=0, high=15, shape=(x, y), dtype=np.uint8
+        low=0,
+        high=15,
+        shape=(x, y),
+        dtype=OBSERVATION_DESC["colors"]["dtype"],
     ),
     "specials_crop": lambda x, y: gym.spaces.Box(
-        low=0, high=255, shape=(x, y), dtype=np.uint8
+        low=0,
+        high=255,
+        shape=(x, y),
+        dtype=OBSERVATION_DESC["specials"]["dtype"],
     ),
     "tty_chars_crop": lambda x, y: gym.spaces.Box(
-        low=0, high=255, shape=(x, y), dtype=np.uint8
+        low=0,
+        high=255,
+        shape=(x, y),
+        dtype=OBSERVATION_DESC["tty_chars"]["dtype"],
     ),
     "tty_colors_crop": lambda x, y: gym.spaces.Box(
-        low=0, high=31, shape=(x, y), dtype=np.uint8
+        low=0,
+        high=31,
+        shape=(x, y),
+        dtype=OBSERVATION_DESC["tty_colors"]["dtype"],
     ),
     "screen_descriptions_crop": lambda x, y: gym.spaces.Box(
         low=0,
         high=127,
         shape=(x, y, _pynethack.nethack.NLE_SCREEN_DESCRIPTION_LENGTH),
-        dtype=np.uint8,
+        dtype=OBSERVATION_DESC["screen_descriptions"]["dtype"],
     ),
     "pixel_crop": lambda x, y: gym.spaces.Box(
         low=0,
@@ -270,7 +288,7 @@ class MiniHack(NetHackStaircase):
                 )
             else:
                 if "pixel" in self._minihack_obs_keys:
-                    d_shape = nethack.OBSERVATION_DESC["glyphs"]["shape"]
+                    d_shape = OBSERVATION_DESC["glyphs"]["shape"]
                     shape = (
                         d_shape[0] * N_TILE_PIXEL,
                         d_shape[1] * N_TILE_PIXEL,

--- a/minihack/envs/__init__.py
+++ b/minihack/envs/__init__.py
@@ -1,1 +1,14 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+
+import gym
+from gym.envs import registration
+
+
+def register(id, **kwargs):
+    if gym.__version__ >= "0.21":
+        # Starting with version 0.21, gym wraps everything by the
+        # OrderEnforcing wrapper by default (which isn't in gym.wrappers).
+        # This breaks our seed() calls and some other code. Disable.
+        kwargs["order_enforce"] = False
+
+    registration.register(id, **kwargs)

--- a/minihack/envs/boxohack.py
+++ b/minihack/envs/boxohack.py
@@ -5,7 +5,7 @@ import random
 import numpy as np
 import pkg_resources
 from nle import nethack
-from gym.envs import registration
+from minihack.envs import register
 from minihack import LevelGenerator, MiniHackNavigation
 
 LEVELS_PATH = os.path.join(
@@ -161,15 +161,15 @@ class MiniHackBoxobanHard(BoxoHack):
         super().__init__(*args, **kwargs)
 
 
-registration.register(
+register(
     id="MiniHack-Boxoban-Unfiltered-v0",
     entry_point="minihack.envs.boxohack:MiniHackBoxobanUnfiltered",
 )
-registration.register(
+register(
     id="MiniHack-Boxoban-Medium-v0",
     entry_point="minihack.envs.boxohack:MiniHackBoxobanMedium",
 )
-registration.register(
+register(
     id="MiniHack-Boxoban-Hard-v0",
     entry_point="minihack.envs.boxohack:MiniHackBoxobanHard",
 )

--- a/minihack/envs/corridor.py
+++ b/minihack/envs/corridor.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackNavigation
-from gym.envs import registration
+from minihack.envs import register
 from nle import nethack
 
 MOVE_ACTIONS = tuple(nethack.CompassDirection)
@@ -39,15 +39,15 @@ class MiniHackCorridor5(MiniHackCorridor):
         super().__init__(*args, des_file="corridor5.des", **kwargs)
 
 
-registration.register(
+register(
     id="MiniHack-Corridor-R2-v0",
     entry_point="minihack.envs.corridor:MiniHackCorridor2",
 )
-registration.register(
+register(
     id="MiniHack-Corridor-R3-v0",
     entry_point="minihack.envs.corridor:MiniHackCorridor3",
 )
-registration.register(
+register(
     id="MiniHack-Corridor-R5-v0",
     entry_point="minihack.envs.corridor:MiniHackCorridor5",
 )

--- a/minihack/envs/exploremaze.py
+++ b/minihack/envs/exploremaze.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-from gym.envs import registration
+from minihack.envs import register
 from minihack import MiniHackNavigation
 from minihack.envs.corridor import NAVIGATE_ACTIONS
 from minihack.reward_manager import RewardManager
@@ -70,19 +70,19 @@ class MiniHackExploreMazeHardMapped(MiniHackExploreMaze):
         )
 
 
-registration.register(
+register(
     id="MiniHack-ExploreMaze-Easy-v0",
     entry_point="minihack.envs.exploremaze:MiniHackExploreMazeEasy",
 )
-registration.register(
+register(
     id="MiniHack-ExploreMaze-Hard-v0",
     entry_point="minihack.envs.exploremaze:MiniHackExploreMazeHard",
 )
-registration.register(
+register(
     id="MiniHack-ExploreMaze-Easy-Mapped-v0",
     entry_point="minihack.envs.exploremaze:MiniHackExploreMazeEasyMapped",
 )
-registration.register(
+register(
     id="MiniHack-ExploreMaze-Hard-Mapped-v0",
     entry_point="minihack.envs.exploremaze:MiniHackExploreMazeHardMapped",
 )

--- a/minihack/envs/fightcorridor.py
+++ b/minihack/envs/fightcorridor.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackNavigation, LevelGenerator
-from gym.envs import registration
+from minihack.envs import register
 
 
 class MiniHackFightCorridor(MiniHackNavigation):
@@ -33,12 +33,12 @@ class MiniHackFightCorridorDark(MiniHackFightCorridor):
         super().__init__(*args, lit=False, **kwargs)
 
 
-registration.register(
+register(
     id="MiniHack-CorridorBattle-v0",
     entry_point="minihack.envs.fightcorridor:MiniHackFightCorridor",
 )
 
-registration.register(
+register(
     id="MiniHack-CorridorBattle-Dark-v0",
     entry_point="minihack.envs.fightcorridor:MiniHackFightCorridorDark",
 )

--- a/minihack/envs/hidenseek.py
+++ b/minihack/envs/hidenseek.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackNavigation
-from gym.envs import registration
+from minihack.envs import register
 
 
 class MiniHackHideAndSeekMapped(MiniHackNavigation):
@@ -27,19 +27,19 @@ class MiniHackHideAndSeekBig(MiniHackNavigation):
         super().__init__(*args, des_file="hidenseek_big.des", **kwargs)
 
 
-registration.register(
+register(
     id="MiniHack-HideNSeek-Mapped-v0",
     entry_point="minihack.envs.hidenseek:MiniHackHideAndSeekMapped",
 )
-registration.register(
+register(
     id="MiniHack-HideNSeek-v0",
     entry_point="minihack.envs.hidenseek:MiniHackHideAndSeek",
 )
-registration.register(
+register(
     id="MiniHack-HideNSeek-Lava-v0",
     entry_point="minihack.envs.hidenseek:MiniHackHideAndSeekLava",
 )
-registration.register(
+register(
     id="MiniHack-HideNSeek-Big-v0",
     entry_point="minihack.envs.hidenseek:MiniHackHideAndSeekBig",
 )

--- a/minihack/envs/keyroom.py
+++ b/minihack/envs/keyroom.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackNavigation
 from minihack.level_generator import PATH_DAT_DIR
-from gym.envs import registration
+from minihack.envs import register
 from nle.nethack import Command
 from nle import nethack
 import os
@@ -112,23 +112,23 @@ class MiniHackKeyRoom15x15Dark(MiniHackKeyRoom):
         )
 
 
-registration.register(
+register(
     id="MiniHack-KeyRoom-Fixed-S5-v0",
     entry_point="minihack.envs.keyroom:MiniHackKeyRoom5x5Fixed",
 )
-registration.register(
+register(
     id="MiniHack-KeyRoom-S5-v0",
     entry_point="minihack.envs.keyroom:MiniHackKeyRoom5x5",
 )
-registration.register(
+register(
     id="MiniHack-KeyRoom-S15-v0",
     entry_point="minihack.envs.keyroom:MiniHackKeyRoom15x15",
 )
-registration.register(
+register(
     id="MiniHack-KeyRoom-Dark-S5-v0",
     entry_point="minihack.envs.keyroom:MiniHackKeyRoom5x5Dark",
 )
-registration.register(
+register(
     id="MiniHack-KeyRoom-Dark-S15-v0",
     entry_point="minihack.envs.keyroom:MiniHackKeyRoom15x15Dark",
 )

--- a/minihack/envs/lab.py
+++ b/minihack/envs/lab.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackNavigation, LevelGenerator
-from gym.envs import registration
+from minihack.envs import register
 
 
 class MiniHackLabyrinth(MiniHackNavigation):
@@ -71,12 +71,12 @@ class MiniHackLabyrinthSmall(MiniHackNavigation):
         )
 
 
-registration.register(
+register(
     id="MiniHack-Labyrinth-Big-v0",
     entry_point="minihack.envs.lab:MiniHackLabyrinth",
 )
 
-registration.register(
+register(
     id="MiniHack-Labyrinth-Small-v0",
     entry_point="minihack.envs.lab:MiniHackLabyrinthSmall",
 )

--- a/minihack/envs/mazewalk.py
+++ b/minihack/envs/mazewalk.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackNavigation
 from minihack.level_generator import LevelGenerator
-from gym.envs import registration
+from minihack.envs import register
 
 DUNGEON_SHAPE = (76, 21)
 
@@ -63,27 +63,27 @@ class MiniHackMazeWalk45x19Premapped(MiniHackMazeWalk):
         super().__init__(*args, w=45, h=19, premapped=True, **kwargs)
 
 
-registration.register(
+register(
     id="MiniHack-MazeWalk-9x9-v0",
     entry_point="minihack.envs.mazewalk:MiniHackMazeWalk9x9",
 )
-registration.register(
+register(
     id="MiniHack-MazeWalk-Mapped-9x9-v0",
     entry_point="minihack.envs.mazewalk:MiniHackMazeWalk9x9Premapped",
 )
-registration.register(
+register(
     id="MiniHack-MazeWalk-15x15-v0",
     entry_point="minihack.envs.mazewalk:MiniHackMazeWalk15x15",
 )
-registration.register(
+register(
     id="MiniHack-MazeWalk-Mapped-15x15-v0",
     entry_point="minihack.envs.mazewalk:MiniHackMazeWalk15x15Premapped",
 )
-registration.register(
+register(
     id="MiniHack-MazeWalk-45x19-v0",
     entry_point="minihack.envs.mazewalk:MiniHackMazeWalk45x19",
 )
-registration.register(
+register(
     id="MiniHack-MazeWalk-Mapped-45x19-v0",
     entry_point="minihack.envs.mazewalk:MiniHackMazeWalk45x19Premapped",
 )

--- a/minihack/envs/memento.py
+++ b/minihack/envs/memento.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-from gym.envs import registration
+from minihack.envs import register
 from minihack import MiniHackNavigation, RewardManager
 
 
@@ -41,18 +41,18 @@ class MiniHackMementoF4(MiniHackMemento):
         super().__init__(*args, des_file="memento_hard.des", **kwargs)
 
 
-registration.register(
+register(
     id="MiniHack-Memento-Short-F2-v0",
     entry_point="minihack.envs.memento:MiniHackMementoShortF2",
 )
 
 
-registration.register(
+register(
     id="MiniHack-Memento-F2-v0",
     entry_point="minihack.envs.memento:MiniHackMementoF2",
 )
 
-registration.register(
+register(
     id="MiniHack-Memento-F4-v0",
     entry_point="minihack.envs.memento:MiniHackMementoF4",
 )

--- a/minihack/envs/minigrid.py
+++ b/minihack/envs/minigrid.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackNavigation, LevelGenerator
 from nle.nethack import Command, CompassDirection
-from gym.envs import registration
+from minihack.envs import register
 import gym
 
 
@@ -132,15 +132,15 @@ class MiniHackMultiRoomN6(MiniGridHack):
         super().__init__(*args, env_name="MiniGrid-MultiRoom-N6-v0", **kwargs)
 
 
-registration.register(
+register(
     id="MiniHack-MultiRoom-N2-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN2",
 )
-registration.register(
+register(
     id="MiniHack-MultiRoom-N4-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN4",
 )
-registration.register(
+register(
     id="MiniHack-MultiRoom-N6-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN6",
 )
@@ -172,15 +172,15 @@ class MiniHackMultiRoomN6Locked(MiniGridHack):
         super().__init__(*args, env_name="MiniGrid-MultiRoom-N6-v0", **kwargs)
 
 
-registration.register(
+register(
     id="MiniHack-MultiRoom-N2-Locked-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN2Locked",
 )
-registration.register(
+register(
     id="MiniHack-MultiRoom-N4-Locked-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN4Locked",
 )
-registration.register(
+register(
     id="MiniHack-MultiRoom-N6-Locked-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN6Locked",
 )
@@ -212,15 +212,15 @@ class MiniHackMultiRoomN6Lava(MiniGridHack):
         super().__init__(*args, env_name="MiniGrid-MultiRoom-N6-v0", **kwargs)
 
 
-registration.register(
+register(
     id="MiniHack-MultiRoom-N2-Lava-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN2Lava",
 )
-registration.register(
+register(
     id="MiniHack-MultiRoom-N4-Lava-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN4Lava",
 )
-registration.register(
+register(
     id="MiniHack-MultiRoom-N6-Lava-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN6Lava",
 )
@@ -253,15 +253,15 @@ class MiniHackMultiRoomN6Monster(MiniGridHack):
 
 
 # MiniGrid: MonsterMultiRoom
-registration.register(
+register(
     id="MiniHack-MultiRoom-N2-Monster-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN2Monster",
 )
-registration.register(
+register(
     id="MiniHack-MultiRoom-N4-Monster-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN4Monster",
 )
-registration.register(
+register(
     id="MiniHack-MultiRoom-N6-Monster-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN6Monster",
 )
@@ -299,58 +299,58 @@ class MiniHackMultiRoomN6Extreme(MiniGridHack):
         super().__init__(*args, env_name="MiniGrid-MultiRoom-N6-v0", **kwargs)
 
 
-registration.register(
+register(
     id="MiniHack-MultiRoom-N2-Extreme-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN2Extreme",
 )
-registration.register(
+register(
     id="MiniHack-MultiRoom-N4-Extreme-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN4Extreme",
 )
-registration.register(
+register(
     id="MiniHack-MultiRoom-N6-Extreme-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN6Extreme",
 )
 
 # MiniGrid: LavaCrossing
-registration.register(
+register(
     id="MiniHack-LavaCrossingS9N1-v0",
     entry_point="minihack.envs.minigrid:MiniGridHack",
     kwargs={"env_name": "MiniGrid-LavaCrossingS9N1-v0"},
 )
-registration.register(
+register(
     id="MiniHack-LavaCrossingS9N2-v0",
     entry_point="minihack.envs.minigrid:MiniGridHack",
     kwargs={"env_name": "MiniGrid-LavaCrossingS9N2-v0"},
 )
-registration.register(
+register(
     id="MiniHack-LavaCrossingS9N3-v0",
     entry_point="minihack.envs.minigrid:MiniGridHack",
     kwargs={"env_name": "MiniGrid-LavaCrossingS9N3-v0"},
 )
-registration.register(
+register(
     id="MiniHack-LavaCrossingS11N5-v0",
     entry_point="minihack.envs.minigrid:MiniGridHack",
     kwargs={"env_name": "MiniGrid-LavaCrossingS11N5-v0"},
 )
 
 # MiniGrid: Simple Crossing
-registration.register(
+register(
     id="MiniHack-SimpleCrossingS9N1-v0",
     entry_point="minihack.envs.minigrid:MiniGridHack",
     kwargs={"env_name": "MiniGrid-SimpleCrossingS9N1-v0"},
 )
-registration.register(
+register(
     id="MiniHack-SimpleCrossingS9N2-v0",
     entry_point="minihack.envs.minigrid:MiniGridHack",
     kwargs={"env_name": "MiniGrid-SimpleCrossingS9N2-v0"},
 )
-registration.register(
+register(
     id="MiniHack-SimpleCrossingS9N3-v0",
     entry_point="minihack.envs.minigrid:MiniGridHack",
     kwargs={"env_name": "MiniGrid-SimpleCrossingS9N3-v0"},
 )
-registration.register(
+register(
     id="MiniHack-SimpleCrossingS11N5-v0",
     entry_point="minihack.envs.minigrid:MiniGridHack",
     kwargs={"env_name": "MiniGrid-SimpleCrossingS11N5-v0"},

--- a/minihack/envs/river.py
+++ b/minihack/envs/river.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackNavigation, LevelGenerator
-from gym.envs import registration
+from minihack.envs import register
 
 
 class MiniHackRiver(MiniHackNavigation):
@@ -81,27 +81,27 @@ class MiniHackRiverNarrow(MiniHackRiver):
         super().__init__(*args, narrow=True, **kwargs)
 
 
-registration.register(
+register(
     id="MiniHack-River-v0",
     entry_point="minihack.envs.river:MiniHackRiver",
 )
 
-registration.register(
+register(
     id="MiniHack-River-Monster-v0",
     entry_point="minihack.envs.river:MiniHackRiverMonster",
 )
 
-registration.register(
+register(
     id="MiniHack-River-Lava-v0",
     entry_point="minihack.envs.river:MiniHackRiverLava",
 )
 
-registration.register(
+register(
     id="MiniHack-River-MonsterLava-v0",
     entry_point="minihack.envs.river:MiniHackRiverMonsterLava",
 )
 
-registration.register(
+register(
     id="MiniHack-River-Narrow-v0",
     entry_point="minihack.envs.river:MiniHackRiverNarrow",
 )

--- a/minihack/envs/room.py
+++ b/minihack/envs/room.py
@@ -40,7 +40,10 @@ class MiniHackRoom(MiniHackNavigation):
 class MiniHackRoom5x5(MiniHackRoom):
     def __init__(self, *args, **kwargs):
         super().__init__(
-            *args, size=5, random=False, **kwargs, order_enforce=False
+            *args,
+            size=5,
+            random=False,
+            **kwargs,
         )
 
 
@@ -73,7 +76,7 @@ class MiniHackRoom5x5Ultimate(MiniHackRoom):
             lit=False,
             n_monster=1,
             n_trap=1,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -139,7 +142,7 @@ class MiniHackRoom15x15Ultimate(MiniHackRoom):
             lit=False,
             n_monster=3,
             n_trap=15,
-            **kwargs
+            **kwargs,
         )
 
 

--- a/minihack/envs/room.py
+++ b/minihack/envs/room.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackNavigation
 from minihack import LevelGenerator
-from gym.envs import registration
+from minihack.envs import register
 
 
 class MiniHackRoom(MiniHackNavigation):
@@ -39,7 +39,9 @@ class MiniHackRoom(MiniHackNavigation):
 
 class MiniHackRoom5x5(MiniHackRoom):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, size=5, random=False, **kwargs)
+        super().__init__(
+            *args, size=5, random=False, **kwargs, order_enforce=False
+        )
 
 
 class MiniHackRoom5x5Random(MiniHackRoom):
@@ -75,27 +77,27 @@ class MiniHackRoom5x5Ultimate(MiniHackRoom):
         )
 
 
-registration.register(
+register(
     id="MiniHack-Room-5x5-v0",
     entry_point="minihack.envs.room:MiniHackRoom5x5",
 )
-registration.register(
+register(
     id="MiniHack-Room-Random-5x5-v0",
     entry_point="minihack.envs.room:MiniHackRoom5x5Random",
 )
-registration.register(
+register(
     id="MiniHack-Room-Dark-5x5-v0",
     entry_point="minihack.envs.room:MiniHackRoom5x5Dark",
 )
-registration.register(
+register(
     id="MiniHack-Room-Monster-5x5-v0",
     entry_point="minihack.envs.room:MiniHackRoom5x5Monster",
 )
-registration.register(
+register(
     id="MiniHack-Room-Trap-5x5-v0",
     entry_point="minihack.envs.room:MiniHackRoom5x5Trap",
 )
-registration.register(
+register(
     id="MiniHack-Room-Ultimate-5x5-v0",
     entry_point="minihack.envs.room:MiniHackRoom5x5Ultimate",
 )
@@ -141,27 +143,27 @@ class MiniHackRoom15x15Ultimate(MiniHackRoom):
         )
 
 
-registration.register(
+register(
     id="MiniHack-Room-15x15-v0",
     entry_point="minihack.envs.room:MiniHackRoom15x15",
 )
-registration.register(
+register(
     id="MiniHack-Room-Random-15x15-v0",
     entry_point="minihack.envs.room:MiniHackRoom15x15Random",
 )
-registration.register(
+register(
     id="MiniHack-Room-Dark-15x15-v0",
     entry_point="minihack.envs.room:MiniHackRoom15x15Dark",
 )
-registration.register(
+register(
     id="MiniHack-Room-Monster-15x15-v0",
     entry_point="minihack.envs.room:MiniHackRoom15x15Monster",
 )
-registration.register(
+register(
     id="MiniHack-Room-Trap-15x15-v0",
     entry_point="minihack.envs.room:MiniHackRoom15x15Trap",
 )
-registration.register(
+register(
     id="MiniHack-Room-Ultimate-15x15-v0",
     entry_point="minihack.envs.room:MiniHackRoom15x15Ultimate",
 )

--- a/minihack/envs/skills_freeze.py
+++ b/minihack/envs/skills_freeze.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackSkill, LevelGenerator, RewardManager
-from gym.envs import registration
+from minihack.envs import register
 
 freeze_msgs = [
     "The bolt of cold bounces!",  # checks if cold bounces from the wall
@@ -95,19 +95,19 @@ STAIR:rndcoord($right_bank),down
         super().__init__(*args, des_file=des_file, **kwargs)
 
 
-registration.register(
+register(
     id="MiniHack-Freeze-Wand-v0",
     entry_point="minihack.envs.skills_freeze:MiniHackFreezeWand",
 )
-registration.register(
+register(
     id="MiniHack-Freeze-Horn-v0",
     entry_point="minihack.envs.skills_freeze:MiniHackFreezeHorn",
 )
-registration.register(
+register(
     id="MiniHack-Freeze-Random-v0",
     entry_point="minihack.envs.skills_freeze:MiniHackFreezeRandom",
 )
-registration.register(
+register(
     id="MiniHack-Freeze-Lava-v0",
     entry_point="minihack.envs.skills_freeze:MiniHackFreezeLava",
 )

--- a/minihack/envs/skills_lava.py
+++ b/minihack/envs/skills_lava.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackSkill
-from gym.envs import registration
+from minihack.envs import register
 
 
 class MiniHackLCLevitatePotionPickup(MiniHackSkill):
@@ -151,27 +151,27 @@ class MiniHackLC(MiniHackSkill):
         super().__init__(*args, des_file="lava_crossing.des", **kwargs)
 
 
-registration.register(
+register(
     id="MiniHack-LavaCross-Levitate-Potion-Pickup-v0",
     entry_point="minihack.envs.skills_lava:MiniHackLCLevitatePotionPickup",
 )
-registration.register(
+register(
     id="MiniHack-LavaCross-Levitate-Potion-Inv-v0",
     entry_point="minihack.envs.skills_lava:MiniHackLCLevitatePotionInv",
 )
-registration.register(
+register(
     id="MiniHack-LavaCross-Levitate-Ring-Pickup-v0",
     entry_point="minihack.envs.skills_lava:MiniHackLCLevitateRingPickup",
 )
-registration.register(
+register(
     id="MiniHack-LavaCross-Levitate-Ring-Inv-v0",
     entry_point="minihack.envs.skills_lava:MiniHackLCLevitateRingInv",
 )
-registration.register(
+register(
     id="MiniHack-LavaCross-Levitate-v0",
     entry_point="minihack.envs.skills_lava:MiniHackLCLevitate",
 )
-registration.register(
+register(
     id="MiniHack-LavaCross-v0",
     entry_point="minihack.envs.skills_lava:MiniHackLC",
 )

--- a/minihack/envs/skills_levitate.py
+++ b/minihack/envs/skills_levitate.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackSkill, LevelGenerator, RewardManager
-from gym.envs import registration
+from minihack.envs import register
 
 
 levitation_msg = [
@@ -114,31 +114,31 @@ IF [33%] {
         super().__init__(*args, des_file=des_file, **kwargs)
 
 
-registration.register(
+register(
     id="MiniHack-Levitate-Boots-v0",
     entry_point="minihack.envs.skills_levitate:MiniHackLevitateBoots",
 )
-registration.register(
+register(
     id="MiniHack-Levitate-Ring-v0",
     entry_point="minihack.envs.skills_levitate:MiniHackLevitateRing",
 )
-registration.register(
+register(
     id="MiniHack-Levitate-Potion-v0",
     entry_point="minihack.envs.skills_levitate:MiniHackLevitatePotion",
 )
-registration.register(
+register(
     id="MiniHack-Levitate-Random-v0",
     entry_point="minihack.envs.skills_levitate:MiniHackLevitateRandom",
 )
-registration.register(
+register(
     id="MiniHack-Levitate-Boots-Fixed-v0",
     entry_point="minihack.envs.skills_levitate:MiniHackLevitateBootsFixed",
 )
-registration.register(
+register(
     id="MiniHack-Levitate-Ring-Fixed-v0",
     entry_point="minihack.envs.skills_levitate:MiniHackLevitateRingFixed",
 )
-registration.register(
+register(
     id="MiniHack-Levitate-Potion-Fixed-v0",
     entry_point="minihack.envs.skills_levitate:MiniHackLevitatePotionFixed",
 )

--- a/minihack/envs/skills_quest.py
+++ b/minihack/envs/skills_quest.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackSkill
-from gym.envs import registration
+from minihack.envs import register
 
 
 class MiniHackQuestEasy(MiniHackSkill):
@@ -24,15 +24,15 @@ class MiniHackQuestHard(MiniHackSkill):
         super().__init__(*args, des_file="quest_hard.des", **kwargs)
 
 
-registration.register(
+register(
     id="MiniHack-Quest-Easy-v0",
     entry_point="minihack.envs.skills_quest:MiniHackQuestEasy",
 )
-registration.register(
+register(
     id="MiniHack-Quest-Medium-v0",
     entry_point="minihack.envs.skills_quest:MiniHackQuestMedium",
 )
-registration.register(
+register(
     id="MiniHack-Quest-Hard-v0",
     entry_point="minihack.envs.skills_quest:MiniHackQuestHard",
 )

--- a/minihack/envs/skills_simple.py
+++ b/minihack/envs/skills_simple.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackSkill, LevelGenerator, RewardManager
-from gym.envs import registration
+from minihack.envs import register
 
 
 class MiniHackEat(MiniHackSkill):
@@ -433,117 +433,117 @@ class MiniHackLockedDoorFixed(MiniHackSkill):
 
 
 # Tasks (w/o doors)
-registration.register(
+register(
     id="MiniHack-Eat-v0",
     entry_point="minihack.envs.skills_simple:MiniHackEat",
 )
-registration.register(
+register(
     id="MiniHack-Pray-v0",
     entry_point="minihack.envs.skills_simple:MiniHackPray",
 )
-registration.register(
+register(
     id="MiniHack-Sink-v0",
     entry_point="minihack.envs.skills_simple:MiniHackSink",
 )
-registration.register(
+register(
     id="MiniHack-Wield-v0",
     entry_point="minihack.envs.skills_simple:MiniHackWield",
 )
-registration.register(
+register(
     id="MiniHack-Wear-v0",
     entry_point="minihack.envs.skills_simple:MiniHackWear",
 )
-registration.register(
+register(
     id="MiniHack-PutOn-v0",
     entry_point="minihack.envs.skills_simple:MiniHackPutOn",
 )
-registration.register(
+register(
     id="MiniHack-Zap-v0",
     entry_point="minihack.envs.skills_simple:MiniHackZap",
 )
-registration.register(
+register(
     id="MiniHack-Read-v0",
     entry_point="minihack.envs.skills_simple:MiniHackRead",
 )
 
 # Fixed version of tasks
-registration.register(
+register(
     id="MiniHack-Eat-Fixed-v0",
     entry_point="minihack.envs.skills_simple:MiniHackEatFixed",
 )
-registration.register(
+register(
     id="MiniHack-Pray-Fixed-v0",
     entry_point="minihack.envs.skills_simple:MiniHackPrayFixed",
 )
-registration.register(
+register(
     id="MiniHack-Sink-Fixed-v0",
     entry_point="minihack.envs.skills_simple:MiniHackSinkFixed",
 )
-registration.register(
+register(
     id="MiniHack-Wield-Fixed-v0",
     entry_point="minihack.envs.skills_simple:MiniHackWieldFixed",
 )
-registration.register(
+register(
     id="MiniHack-Wear-Fixed-v0",
     entry_point="minihack.envs.skills_simple:MiniHackWearFixed",
 )
-registration.register(
+register(
     id="MiniHack-PutOn-Fixed-v0",
     entry_point="minihack.envs.skills_simple:MiniHackPutOnFixed",
 )
-registration.register(
+register(
     id="MiniHack-Zap-Fixed-v0",
     entry_point="minihack.envs.skills_simple:MiniHackZapFixed",
 )
-registration.register(
+register(
     id="MiniHack-Read-Fixed-v0",
     entry_point="minihack.envs.skills_simple:MiniHackReadFixed",
 )
 
 # Task versions with random distractions
-registration.register(
+register(
     id="MiniHack-Eat-Distr-v0",
     entry_point="minihack.envs.skills_simple:MiniHackEatDistr",
 )
-registration.register(
+register(
     id="MiniHack-Pray-Distr-v0",
     entry_point="minihack.envs.skills_simple:MiniHackPrayDistr",
 )
-registration.register(
+register(
     id="MiniHack-Sink-Distr-v0",
     entry_point="minihack.envs.skills_simple:MiniHackSinkDistr",
 )
-registration.register(
+register(
     id="MiniHack-Wield-Distr-v0",
     entry_point="minihack.envs.skills_simple:MiniHackWieldDistr",
 )
-registration.register(
+register(
     id="MiniHack-Wear-Distr-v0",
     entry_point="minihack.envs.skills_simple:MiniHackWearDistr",
 )
-registration.register(
+register(
     id="MiniHack-PutOn-Distr-v0",
     entry_point="minihack.envs.skills_simple:MiniHackPutOnDistr",
 )
-registration.register(
+register(
     id="MiniHack-Zap-Distr-v0",
     entry_point="minihack.envs.skills_simple:MiniHackZapDistr",
 )
-registration.register(
+register(
     id="MiniHack-Read-Distr-v0",
     entry_point="minihack.envs.skills_simple:MiniHackReadDistr",
 )
 
 # Tasks involvign doors
-registration.register(
+register(
     id="MiniHack-ClosedDoor-v0",
     entry_point="minihack.envs.skills_simple:MiniHackClosedDoor",
 )
-registration.register(
+register(
     id="MiniHack-LockedDoor-v0",
     entry_point="minihack.envs.skills_simple:MiniHackLockedDoor",
 )
-registration.register(
+register(
     id="MiniHack-LockedDoor-Fixed-v0",
     entry_point="minihack.envs.skills_simple:MiniHackLockedDoorFixed",
 )

--- a/minihack/envs/skills_wod.py
+++ b/minihack/envs/skills_wod.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackSkill, LevelGenerator, RewardManager
-from gym.envs import registration
+from minihack.envs import register
 
 
 class MiniHackWoDEasy(MiniHackSkill):
@@ -121,20 +121,20 @@ class MiniHackWoDPro(MiniHackSkill):
         )
 
 
-registration.register(
+register(
     id="MiniHack-WoD-Easy-v0",
     entry_point="minihack.envs.skills_wod:MiniHackWoDEasy",
 )
 
-registration.register(
+register(
     id="MiniHack-WoD-Medium-v0",
     entry_point="minihack.envs.skills_wod:MiniHackWoDMedium",
 )
-registration.register(
+register(
     id="MiniHack-WoD-Hard-v0",
     entry_point="minihack.envs.skills_wod:MiniHackWoDHard",
 )
-registration.register(
+register(
     id="MiniHack-WoD-Pro-v0",
     entry_point="minihack.envs.skills_wod:MiniHackWoDPro",
 )

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ entry_points = {
     ]
 }
 
-install_requires = ["numpy>=1.16", "gym<0.20"]
+install_requires = ["numpy>=1.16", "gym"]
 if not os.getenv("READTHEDOCS"):
     install_requires.append("nle>=0.7.3")
 


### PR DESCRIPTION
Associated issue: #29

This is also related to the [same issue in NLE](https://github.com/facebookresearch/nle/pull/271). Due to the recent update on the gym side, gym wraps environments with the `OrderEnforcing` wrapper by default. This breaks our tests and some functionality. Here we disable order enforcing for the environments registered in MiniHack.
