### PR TITLE
Fixing the NetHack variable renaming and _underscore access recently introduced in NLE==0.9.0

### DIFF
--- a/minihack/base.py
+++ b/minihack/base.py
@@ -186,11 +186,14 @@ class MiniHack(NetHackStaircase):
             penalty_time (float):
                 A constant applied to amount of frozen steps. Defaults to -0.0.
                 Inherited from `NetHackScore`.
-            savedir (str or None): path to save ttyrecs (game recordings) into.
-                Defaults to None, which doesn't save any data. Otherwise,
-                interpreted as a path to a new or existing directory.
-                If "" (empty string), NLE choses a unique directory name.
-                Inherited from `NLE`.
+            save_ttyrec_every (int):
+                Integer, if 0, no ttyrecs (game recordings) will
+                be saved. Otherwise, save a ttyrec every Nth episode.
+            savedir (str or None):
+                Path to save ttyrecs (game recordings) into,
+                if save_ttyrec_every is nonzero. If nonempty string, interpreted
+                as a path to a new or existing directory.
+                If "" (empty string) or None, NLE choses a unique directory name.
             character (str):
                 Name of character. Defaults to "mon-hum-neu-mal". Interited
                 from `NLE`.
@@ -212,6 +215,9 @@ class MiniHack(NetHackStaircase):
                 If set to True, do not decline menus, text input or auto
                 'MORE'. If set to False, only skip click through 'MORE'
                 on death. Inherited from `NLE`.
+            spawn_monsters (bool):
+                If False, disables normal NetHack behavior to randomly
+                create monsters.
         """
         # NetHack options
         options: Tuple = MH_NETHACKOPTIONS

--- a/minihack/base.py
+++ b/minihack/base.py
@@ -189,35 +189,37 @@ class MiniHack(NetHackStaircase):
             save_ttyrec_every (int):
                 Integer, if 0, no ttyrecs (game recordings) will
                 be saved. Otherwise, save a ttyrec every Nth episode.
+                Defaults to 0. Inherited from `NLE`.
             savedir (str or None):
                 Path to save ttyrecs (game recordings) into,
-                if save_ttyrec_every is nonzero. If nonempty string, interpreted
-                as a path to a new or existing directory.
-                If "" (empty string) or None, NLE choses a unique directory name.
+                if save_ttyrec_every is nonzero. If nonempty string,
+                interpreted as a path to a new or existing directory.
+                If "" (empty string) or None, NLE choses a unique directory
+                name. Defaults to None. Inherited from `NLE`.
             character (str):
                 Name of character. Defaults to "mon-hum-neu-mal". Interited
                 from `NLE`.
             max_episode_steps (int):
                 maximum amount of steps allowed before the game is forcefully
                 quit.  In such cases, ``info["end_status"]`` ill be equal to
-                ``StepStatus.ABORTED``. Defaults to 5000. Inherited from `NLE`.
+                ``StepStatus.ABORTED``. Defaults to 200. Inherited from `NLE`.
             actions (list):
                 list of actions. If None, the full action space will
-                be used, i.e. ``nle.nethack.ACTIONS``. Defaults to None.
-                Inherited from `NLE`.
+                be used, i.e. ``nle.nethack.ACTIONS``. Defaults to
+                `MH_FULL_ACTIONS`. Inherited from `NLE`.
             wizard (bool):
-                activate wizard mode. Defaults to False.
+                activate wizard mode. Defaults to False. Inherited from `NLE`.
             allow_all_yn_questions (bool):
                 If set to True, no y/n questions in step() are declined.
                 If set to False, only elements of SKIP_EXCEPTIONS are not
-                declined. Defaults to False. Inherited from `NLE`.
+                declined. Defaults to True. Inherited from `NLE`.
             allow_all_modes (bool):
                 If set to True, do not decline menus, text input or auto
                 'MORE'. If set to False, only skip click through 'MORE'
-                on death. Inherited from `NLE`.
+                on death. Defaults to False. Inherited from `NLE`.
             spawn_monsters (bool):
                 If False, disables normal NetHack behavior to randomly
-                create monsters.
+                create monsters. Defaults to False. Inherited from `NLE`.
         """
         # NetHack options
         options: Tuple = MH_NETHACKOPTIONS
@@ -226,7 +228,7 @@ class MiniHack(NetHackStaircase):
         if not pet:
             options += ("pettype:none",)
         kwargs["options"] = kwargs.pop("options", options)
-        # Actions space - move only
+        # Actions space
         kwargs["actions"] = kwargs.pop("actions", MH_FULL_ACTIONS)
 
         # Enter Wizard mode - turned off by default

--- a/minihack/base.py
+++ b/minihack/base.py
@@ -365,7 +365,7 @@ class MiniHack(NetHackStaircase):
         hackdir directory of the environment.
         """
         if not des_file.endswith(".des"):
-            fpath = os.path.join(self.env._vardir, "mylevel.des")
+            fpath = os.path.join(self.nethack._vardir, "mylevel.des")
             # If the des-file is passed as a string
             with open(fpath, "w") as f:
                 f.writelines(des_file)
@@ -386,7 +386,7 @@ class MiniHack(NetHackStaircase):
             _ = subprocess.call(
                 [
                     PATCH_SCRIPT,
-                    self.env._vardir,
+                    self.nethack._vardir,
                     HACKDIR,
                     LIB_DIR,
                     des_path,

--- a/minihack/envs/keyroom.py
+++ b/minihack/envs/keyroom.py
@@ -39,7 +39,7 @@ class MiniHackKeyDoor(MiniHackNavigation):
 
     def step(self, action: int):
         # If apply action is chosen
-        if self._actions[action] == Command.APPLY:
+        if self.actions[action] == Command.APPLY:
             key_key = self.key_in_inventory("key")
             # if key is in the inventory
             if key_key is not None:

--- a/minihack/envs/keyroom.py
+++ b/minihack/envs/keyroom.py
@@ -47,16 +47,16 @@ class MiniHackKeyDoor(MiniHackNavigation):
                 dir_key = self.get_object_direction("closed door")
                 if dir_key is not None:
                     # Perform the following NetHack steps
-                    self.env.step(Command.APPLY)  # press apply
-                    self.env.step(ord(key_key))  # choose key from the inv
-                    self.env.step(dir_key)  # select the door's direction
-                    obs, done = self.env.step(ord("y"))  # press y
+                    self.nethack.step(Command.APPLY)  # press apply
+                    self.nethack.step(ord(key_key))  # choose key from the inv
+                    self.nethack.step(dir_key)  # select the door's direction
+                    obs, done = self.nethack.step(ord("y"))  # press y
                     obs, done = self._perform_known_steps(
                         obs, done, exceptions=True
                     )
                     # Make sure the door is open
                     while True:
-                        obs, done = self.env.step(dir_key)
+                        obs, done = self.nethack.step(dir_key)
                         obs, done = self._perform_known_steps(
                             obs, done, exceptions=True
                         )

--- a/minihack/scripts/play.py
+++ b/minihack/scripts/play.py
@@ -60,7 +60,7 @@ def get_action(env, action_mode, is_raw_env):
                 if is_raw_env:
                     action = ch
                 else:
-                    action = env._actions.index(ch)
+                    action = env.actions.index(ch)
                 break
             except ValueError:
                 print(
@@ -120,7 +120,7 @@ def play(
         if seeds is not None:
             env.seed(seeds)
         if not no_render:
-            print("Available actions:", env._actions)
+            print("Available actions:", env.actions)
 
     obs = env.reset()
 
@@ -144,7 +144,7 @@ def play(
             if not is_raw_env:
                 print("Previous reward:", reward)
                 if action is not None:
-                    print("Previous action: %s" % repr(env._actions[action]))
+                    print("Previous action: %s" % repr(env.actions[action]))
                 env.render(render_mode)
             else:
                 print("Previous action:", action)

--- a/minihack/scripts/play_gui.py
+++ b/minihack/scripts/play_gui.py
@@ -51,7 +51,7 @@ def main():
             ch = ord(event.key)
 
         try:
-            action = env._actions.index(ch)
+            action = env.actions.index(ch)
             step(action)
         except (ValueError, TypeError):
             print(

--- a/minihack/tests/test_envs.py
+++ b/minihack/tests/test_envs.py
@@ -128,11 +128,11 @@ class TestGymEnv:
     def test_default_wizard_mode(self, env_name, wizard):
         if wizard:
             env = gym.make(env_name, wizard=wizard)
-            assert "playmode:debug" in env.env._options
+            assert "playmode:debug" in env.nethack._options
         else:
             # do not send a parameter to test a default
             env = gym.make(env_name)
-            assert "playmode:debug" not in env.env._options
+            assert "playmode:debug" not in env.nethack._options
 
 
 @pytest.mark.parametrize(

--- a/minihack/tests/test_envs.py
+++ b/minihack/tests/test_envs.py
@@ -154,20 +154,24 @@ class TestGymEnvRollout:
     def test_rollout(self, env_name, rollout_len):
         """Tests rollout_len steps (or until termination) of random policy."""
         with tempfile.TemporaryDirectory() as savedir:
-            env = gym.make(env_name, savedir=savedir)
+            env = gym.make(env_name, save_ttyrec_every=1, savedir=savedir)
             rollout_env(env, rollout_len)
             env.close()
 
             assert os.path.exists(
-                os.path.join(savedir, "nle.%i.0.ttyrec.bz2" % os.getpid())
+                os.path.join(
+                    savedir,
+                    "nle.%i.0.ttyrec%i.bz2" % (os.getpid(), nethack.TTYREC_VERSION),
+                )
+            )
+            assert os.path.exists(
+                os.path.join(savedir, "nle.%i.xlogfile" % os.getpid())
             )
 
     def test_rollout_no_archive(self, env_name, rollout_len):
         """Tests rollout_len steps (or until termination) of random policy."""
         env = gym.make(env_name, savedir=None)
         assert env.savedir is None
-        assert env._stats_file is None
-        assert env._stats_logger is None
         rollout_env(env, rollout_len)
 
     def test_seed_interface_output(self, env_name, rollout_len):

--- a/minihack/tests/test_envs.py
+++ b/minihack/tests/test_envs.py
@@ -128,11 +128,11 @@ class TestGymEnv:
     def test_default_wizard_mode(self, env_name, wizard):
         if wizard:
             env = gym.make(env_name, wizard=wizard)
-            assert "playmode:debug" in env.nethack._options
+            assert "playmode:debug" in env.nethack.options
         else:
             # do not send a parameter to test a default
             env = gym.make(env_name)
-            assert "playmode:debug" not in env.nethack._options
+            assert "playmode:debug" not in env.nethack.options
 
 
 @pytest.mark.parametrize(
@@ -279,17 +279,17 @@ class TestRoomReward:
         _ = env.reset()
 
         for _ in range(4):
-            _, reward, done, _ = env.step(env._actions.index(ord("j")))
+            _, reward, done, _ = env.step(env.actions.index(ord("j")))
             assert reward == 0.0
             assert not done
 
         for _ in range(3):
-            _, reward, done, _ = env.step(env._actions.index(ord("l")))
+            _, reward, done, _ = env.step(env.actions.index(ord("l")))
             assert reward == 0.0
             assert not done
 
         # Hack to quit.
-        _, reward, done, _ = env.step(env._actions.index(ord("l")))
+        _, reward, done, _ = env.step(env.actions.index(ord("l")))
 
         assert done
         assert reward == 1.0

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ entry_points = {
 
 install_requires = ["numpy>=1.16", "gym>=0.15,<=0.23"]
 if not os.getenv("READTHEDOCS"):
-    install_requires.append("nle>=0.8.1")
+    install_requires.append("nle==0.9.0")
 
 extras_deps = {
     "dev": [


### PR DESCRIPTION
Fixing issues associated with NLE==0.9.0 release. This concerns the removal of _underscored vars in `nle` base class and renaming` nle.env` to `nle.nethack`.
Closes #64.