### PR TITLE
Add extra tasks used in E3B paper

### DIFF
--- a/minihack/envs/minigrid.py
+++ b/minihack/envs/minigrid.py
@@ -155,6 +155,38 @@ class MiniHackMultiRoomN6(MiniGridHack):
         super().__init__(*args, env_name="MiniGrid-MultiRoom-N6-v0", **kwargs)
 
 
+
+register(
+    id="MiniGrid-MultiRoom-N10-v0",
+    entry_point="gym_minigrid.envs:MultiRoomEnv",
+    kwargs={"minNumRooms": 10, "maxNumRooms": 10},
+)
+
+        
+class MiniHackMultiRoomN10(MiniGridHack):
+    def __init__(self, *args, **kwargs):
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 360)
+        super().__init__(*args, env_name="MiniGrid-MultiRoom-N10-v0", **kwargs)
+
+
+# open door version of the above envs - methods with message-based bonuses tend to fail on these
+# because there is no message "the door opens" when visiting a new room
+
+class MiniHackMultiRoomN6OpenDoor(MiniGridHack):
+    def __init__(self, *args, **kwargs):
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 240)
+        kwargs["door_state"] = kwargs.pop("door_state", "open")
+        super().__init__(*args, env_name="MiniGrid-MultiRoom-N6-v0", **kwargs)
+        
+
+class MiniHackMultiRoomN10OpenDoor(MiniGridHack):
+    def __init__(self, *args, **kwargs):
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 360)
+        kwargs["door_state"] = kwargs.pop("door_state", "open")
+        super().__init__(*args, env_name="MiniGrid-MultiRoom-N10-v0", **kwargs)
+
+
+
 register(
     id="MiniHack-MultiRoom-N2-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN2",
@@ -167,6 +199,19 @@ register(
     id="MiniHack-MultiRoom-N6-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN6",
 )
+register(
+    id="MiniHack-MultiRoom-N10-v0",
+    entry_point="minihack.envs.minigrid:MiniHackMultiRoomN10",
+)
+register(
+    id="MiniHack-MultiRoom-N6-OpenDoor-v0",
+    entry_point="minihack.envs.minigrid:MiniHackMultiRoomN6OpenDoor",
+)
+register(
+    id="MiniHack-MultiRoom-N10-OpenDoor-v0",
+    entry_point="minihack.envs.minigrid:MiniHackMultiRoomN10OpenDoor",
+)
+
 
 
 # MiniGrid: LockedMultiRoom
@@ -234,6 +279,31 @@ class MiniHackMultiRoomN6Lava(MiniGridHack):
         kwargs["lava_walls"] = True
         super().__init__(*args, env_name="MiniGrid-MultiRoom-N6-v0", **kwargs)
 
+        
+class MiniHackMultiRoomN10Lava(MiniGridHack):
+    def __init__(self, *args, **kwargs):
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 360)
+        kwargs["lava_walls"] = True
+        super().__init__(*args, env_name="MiniGrid-MultiRoom-N10-v0", **kwargs)
+
+
+class MiniHackMultiRoomN6LavaOpenDoor(MiniGridHack):
+    def __init__(self, *args, **kwargs):
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 240)
+        kwargs["lava_walls"] = True
+        kwargs["door_state"] = kwargs.pop("door_state", "open")        
+        super().__init__(*args, env_name="MiniGrid-MultiRoom-N6-v0", **kwargs)
+
+        
+class MiniHackMultiRoomN10LavaOpenDoor(MiniGridHack):
+    def __init__(self, *args, **kwargs):
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 360)
+        kwargs["lava_walls"] = True
+        kwargs["door_state"] = kwargs.pop("door_state", "open")        
+        super().__init__(*args, env_name="MiniGrid-MultiRoom-N10-v0", **kwargs)
+        
+        
+
 
 register(
     id="MiniHack-MultiRoom-N2-Lava-v0",
@@ -247,6 +317,19 @@ register(
     id="MiniHack-MultiRoom-N6-Lava-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN6Lava",
 )
+register(
+    id="MiniHack-MultiRoom-N10-Lava-v0",
+    entry_point="minihack.envs.minigrid:MiniHackMultiRoomN10Lava",
+)
+register(
+    id="MiniHack-MultiRoom-N6-Lava-OpenDoor-v0",
+    entry_point="minihack.envs.minigrid:MiniHackMultiRoomN6LavaOpenDoor",
+)
+register(
+    id="MiniHack-MultiRoom-N10-Lava-OpenDoor-v0",
+    entry_point="minihack.envs.minigrid:MiniHackMultiRoomN10LavaOpenDoor",
+)
+
 
 
 # MiniGrid: MonsterpedMultiRoom
@@ -288,6 +371,7 @@ register(
     id="MiniHack-MultiRoom-N6-Monster-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN6Monster",
 )
+
 
 
 # MiniGrid: ExtremeMultiRoom
@@ -335,7 +419,66 @@ register(
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN6Extreme",
 )
 
+
+# MiniGrid: The N6-Extreme-v0 env above is impossible to solve consistently even for a human 
+# due to too many monsters. Here are some easier envs with lava and fewer monsters. 
+
+class MiniHackMultiRoomN2LavaMonsters(MiniGridHack):
+    def __init__(self, *args, **kwargs):
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 40)
+        kwargs["num_mon"] = 1
+        kwargs["lava_walls"] = True
+        super().__init__(
+            *args, env_name="MiniGrid-MultiRoom-N2-S4-v0", **kwargs
+        )
+
+
+class MiniHackMultiRoomN4LavaMonsters(MiniGridHack):
+    def __init__(self, *args, **kwargs):
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 120)
+        kwargs["num_mon"] = 2
+        kwargs["lava_walls"] = True
+        super().__init__(
+            *args, env_name="MiniGrid-MultiRoom-N4-S5-v0", **kwargs
+        )
+
+
+class MiniHackMultiRoomN6LavaMonsters(MiniGridHack):
+    def __init__(self, *args, **kwargs):
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 240)
+        kwargs["num_mon"] = 3
+        kwargs["lava_walls"] = True
+        super().__init__(*args, env_name="MiniGrid-MultiRoom-N6-v0", **kwargs)
+
+
+register(
+    id="MiniHack-MultiRoom-N2-LavaMonsters-v0",
+    entry_point="minihack.envs.minigrid:MiniHackMultiRoomN2LavaMonsters",
+)
+register(
+    id="MiniHack-MultiRoom-N4-LavaMonsters-v0",
+    entry_point="minihack.envs.minigrid:MiniHackMultiRoomN4LavaMonsters",
+)
+register(
+    id="MiniHack-MultiRoom-N6-LavaMonsters-v0",
+    entry_point="minihack.envs.minigrid:MiniHackMultiRoomN6LavaMonsters",
+)
+
+
 # MiniGrid: LavaCrossing
+register(
+    id="MiniGrid-LavaCrossingS19N13-v0",
+    entry_point="gym_minigrid.envs:CrossingEnv",
+    kwargs={"size": 19, "num_crossings": 13},
+)
+register(
+    id="MiniGrid-LavaCrossingS19N17-v0",
+    entry_point="gym_minigrid.envs:CrossingEnv",
+    kwargs={"size": 19, "num_crossings": 17},
+)
+
+
+
 register(
     id="MiniHack-LavaCrossingS9N1-v0",
     entry_point="minihack.envs.minigrid:MiniGridHack",
@@ -356,6 +499,18 @@ register(
     entry_point="minihack.envs.minigrid:MiniGridHack",
     kwargs={"env_name": "MiniGrid-LavaCrossingS11N5-v0"},
 )
+register(
+    id="MiniHack-LavaCrossingS19N13-v0",
+    entry_point="minihack.envs.minigrid:MiniGridHack",
+    kwargs={"env_name": "MiniGrid-LavaCrossingS19N13-v0"},
+)
+
+register(
+    id="MiniHack-LavaCrossingS19N17-v0",
+    entry_point="minihack.envs.minigrid:MiniGridHack",
+    kwargs={"env_name": "MiniGrid-LavaCrossingS19N17-v0"},
+)
+
 
 # MiniGrid: Simple Crossing
 register(

--- a/minihack/envs/minigrid.py
+++ b/minihack/envs/minigrid.py
@@ -420,7 +420,7 @@ register(
 )
 
 
-# MiniGrid: The N6-Extreme-v0 env above is impossible to solve consistently even for a human 
+# Note: the N6-Extreme-v0 env above is impossible to solve consistently even for a human 
 # due to too many monsters. Here are some easier envs with lava and fewer monsters. 
 
 class MiniHackMultiRoomN2LavaMonsters(MiniGridHack):

--- a/minihack/envs/minigrid.py
+++ b/minihack/envs/minigrid.py
@@ -155,14 +155,13 @@ class MiniHackMultiRoomN6(MiniGridHack):
         super().__init__(*args, env_name="MiniGrid-MultiRoom-N6-v0", **kwargs)
 
 
-
 register(
     id="MiniGrid-MultiRoom-N10-v0",
     entry_point="gym_minigrid.envs:MultiRoomEnv",
     kwargs={"minNumRooms": 10, "maxNumRooms": 10},
 )
 
-        
+
 class MiniHackMultiRoomN10(MiniGridHack):
     def __init__(self, *args, **kwargs):
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 360)
@@ -172,19 +171,19 @@ class MiniHackMultiRoomN10(MiniGridHack):
 # open door version of the above envs - methods with message-based bonuses tend to fail on these
 # because there is no message "the door opens" when visiting a new room
 
+
 class MiniHackMultiRoomN6OpenDoor(MiniGridHack):
     def __init__(self, *args, **kwargs):
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 240)
         kwargs["door_state"] = kwargs.pop("door_state", "open")
         super().__init__(*args, env_name="MiniGrid-MultiRoom-N6-v0", **kwargs)
-        
+
 
 class MiniHackMultiRoomN10OpenDoor(MiniGridHack):
     def __init__(self, *args, **kwargs):
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 360)
         kwargs["door_state"] = kwargs.pop("door_state", "open")
         super().__init__(*args, env_name="MiniGrid-MultiRoom-N10-v0", **kwargs)
-
 
 
 register(
@@ -211,7 +210,6 @@ register(
     id="MiniHack-MultiRoom-N10-OpenDoor-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN10OpenDoor",
 )
-
 
 
 # MiniGrid: LockedMultiRoom
@@ -279,7 +277,7 @@ class MiniHackMultiRoomN6Lava(MiniGridHack):
         kwargs["lava_walls"] = True
         super().__init__(*args, env_name="MiniGrid-MultiRoom-N6-v0", **kwargs)
 
-        
+
 class MiniHackMultiRoomN10Lava(MiniGridHack):
     def __init__(self, *args, **kwargs):
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 360)
@@ -291,18 +289,16 @@ class MiniHackMultiRoomN6LavaOpenDoor(MiniGridHack):
     def __init__(self, *args, **kwargs):
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 240)
         kwargs["lava_walls"] = True
-        kwargs["door_state"] = kwargs.pop("door_state", "open")        
+        kwargs["door_state"] = kwargs.pop("door_state", "open")
         super().__init__(*args, env_name="MiniGrid-MultiRoom-N6-v0", **kwargs)
 
-        
+
 class MiniHackMultiRoomN10LavaOpenDoor(MiniGridHack):
     def __init__(self, *args, **kwargs):
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 360)
         kwargs["lava_walls"] = True
-        kwargs["door_state"] = kwargs.pop("door_state", "open")        
+        kwargs["door_state"] = kwargs.pop("door_state", "open")
         super().__init__(*args, env_name="MiniGrid-MultiRoom-N10-v0", **kwargs)
-        
-        
 
 
 register(
@@ -329,7 +325,6 @@ register(
     id="MiniHack-MultiRoom-N10-Lava-OpenDoor-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN10LavaOpenDoor",
 )
-
 
 
 # MiniGrid: MonsterpedMultiRoom
@@ -371,7 +366,6 @@ register(
     id="MiniHack-MultiRoom-N6-Monster-v0",
     entry_point="minihack.envs.minigrid:MiniHackMultiRoomN6Monster",
 )
-
 
 
 # MiniGrid: ExtremeMultiRoom
@@ -420,8 +414,9 @@ register(
 )
 
 
-# Note: the N6-Extreme-v0 env above is impossible to solve consistently even for a human 
-# due to too many monsters. Here are some easier envs with lava and fewer monsters. 
+# Note: the N6-Extreme-v0 env above is impossible to solve consistently even for a human
+# due to too many monsters. Here are some easier envs with lava and fewer monsters.
+
 
 class MiniHackMultiRoomN2LavaMonsters(MiniGridHack):
     def __init__(self, *args, **kwargs):
@@ -476,7 +471,6 @@ register(
     entry_point="gym_minigrid.envs:CrossingEnv",
     kwargs={"size": 19, "num_crossings": 17},
 )
-
 
 
 register(

--- a/minihack/envs/skills_freeze.py
+++ b/minihack/envs/skills_freeze.py
@@ -25,6 +25,21 @@ class MiniHackFreezeWand(MiniHackFreeze):
 
         super().__init__(*args, des_file=des_file, **kwargs)
 
+        
+class MiniHackFreezeWandRestrictedActions(MiniHackFreeze):
+    def __init__(self, *args, **kwargs):
+        lvl_gen = LevelGenerator(w=8, h=8, lit=True)
+        lvl_gen.add_object("cold", "/", cursestate="blessed")
+        des_file = lvl_gen.get_des()
+
+        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
+                                                     nethack.Command.ZAP, \
+                                                     nethack.Command.FIRE)
+        kwargs["actions"] = ACTIONS
+        
+
+        super().__init__(*args, des_file=des_file, **kwargs)        
+
 
 class MiniHackFreezeHorn(MiniHackFreeze):
     def __init__(self, *args, **kwargs):
@@ -33,6 +48,22 @@ class MiniHackFreezeHorn(MiniHackFreeze):
         des_file = lvl_gen.get_des()
 
         super().__init__(*args, des_file=des_file, **kwargs)
+
+
+class MiniHackFreezeHornRestrictedActions(MiniHackFreeze):
+    def __init__(self, *args, **kwargs):
+        lvl_gen = LevelGenerator(w=8, h=8, lit=True)
+        lvl_gen.add_object("frost horn", "(", cursestate="blessed")
+        des_file = lvl_gen.get_des()
+
+        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
+                                                     nethack.Command.APPLY, \
+                                                     nethack.Command.FIRE)
+        kwargs["actions"] = ACTIONS
+        
+
+        super().__init__(*args, des_file=des_file, **kwargs)
+        
 
 
 class MiniHackFreezeRandom(MiniHackFreeze):
@@ -61,6 +92,43 @@ IF [50%] {
 }
 """
         super().__init__(*args, des_file=des_file, **kwargs)
+
+
+class MiniHackFreezeRandomRestrictedActions(MiniHackFreeze):
+    def __init__(self, *args, **kwargs):
+        des_file = """
+MAZE: "mylevel", ' '
+FLAGS:hardfloor
+MESSAGE: "Welcome to MiniHack!"
+INIT_MAP: solidfill,' '
+GEOMETRY:center,center
+MAP
+........
+........
+........
+........
+........
+........
+........
+........
+ENDMAP
+REGION:(0,0,7,7),lit,"ordinary"
+IF [50%] {
+    OBJECT:('/',"cold"),random,blessed
+} ELSE {
+    OBJECT:('(',"frost horn"),random,blessed
+}
+"""
+
+        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
+                                                     nethack.Command.ZAP, \
+                                                     nethack.Command.APPLY, \
+                                                     nethack.Command.FIRE)
+        kwargs["actions"] = ACTIONS
+
+        
+        super().__init__(*args, des_file=des_file, **kwargs)
+        
 
 
 class MiniHackFreezeLava(MiniHackSkill):
@@ -95,19 +163,75 @@ STAIR:rndcoord($right_bank),down
         super().__init__(*args, des_file=des_file, **kwargs)
 
 
+class MiniHackFreezeLavaRestrictedActions(MiniHackSkill):
+    def __init__(self, *args, **kwargs):
+        des_file = """
+MAZE: "mylevel", ' '
+FLAGS:hardfloor
+INIT_MAP: solidfill,' '
+GEOMETRY:center,center
+MAP
+-------------
+|.....L.....|
+|.....L.....|
+|.....L.....|
+|.....L.....|
+|.....L.....|
+-------------
+ENDMAP
+REGION:(0,0,12,6),lit,"ordinary"
+$left_bank = selection:fillrect (1,1,5,5)
+$right_bank = selection:fillrect (7,1,11,5)
+IF [50%] {
+    # wand of cold
+    OBJECT:('/',"cold"),rndcoord($left_bank),blessed
+} ELSE {
+    # frost horn
+    OBJECT:('(',"frost horn"),rndcoord($left_bank),blessed
+}
+BRANCH:(1,1,5,5),(0,0,0,0)
+STAIR:rndcoord($right_bank),down
+"""
+        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
+                                                     nethack.Command.ZAP, \
+                                                     nethack.Command.APPLY, \
+                                                     nethack.Command.FIRE)
+        kwargs["actions"] = ACTIONS
+
+        
+        super().__init__(*args, des_file=des_file, **kwargs)
+        
+
+
 register(
-    id="MiniHack-Freeze-Wand-v0",
+    id="MiniHack-Freeze-Wand-Full-v0",
     entry_point="minihack.envs.skills_freeze:MiniHackFreezeWand",
 )
 register(
-    id="MiniHack-Freeze-Horn-v0",
+    id="MiniHack-Freeze-Wand-Restricted-v0",
+    entry_point="minihack.envs.skills_freeze:MiniHackFreezeWandRestrictedActions",
+)
+register(
+    id="MiniHack-Freeze-Horn-Full-v0",
     entry_point="minihack.envs.skills_freeze:MiniHackFreezeHorn",
 )
 register(
-    id="MiniHack-Freeze-Random-v0",
+    id="MiniHack-Freeze-Horn-Restricted-v0",
+    entry_point="minihack.envs.skills_freeze:MiniHackFreezeHornRestrictedActions",
+)
+register(
+    id="MiniHack-Freeze-Random-Full-v0",
     entry_point="minihack.envs.skills_freeze:MiniHackFreezeRandom",
 )
 register(
-    id="MiniHack-Freeze-Lava-v0",
+    id="MiniHack-Freeze-Random-Restricted-v0",
+    entry_point="minihack.envs.skills_freeze:MiniHackFreezeRandomRestrictedActions",
+)
+register(
+    id="MiniHack-Freeze-Lava-Full-v0",
     entry_point="minihack.envs.skills_freeze:MiniHackFreezeLava",
+)
+register(
+    id="MiniHack-Freeze-Lava-Restricted-v0",
+    entry_point="minihack.envs.skills_freeze:MiniHackFreezeLavaRestrictedActions",
 )

--- a/minihack/envs/skills_freeze.py
+++ b/minihack/envs/skills_freeze.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackSkill, LevelGenerator, RewardManager
 from minihack.envs import register
+from nle import nethack
 
 freeze_msgs = [
     "The bolt of cold bounces!",  # checks if cold bounces from the wall

--- a/minihack/envs/skills_freeze.py
+++ b/minihack/envs/skills_freeze.py
@@ -26,20 +26,21 @@ class MiniHackFreezeWand(MiniHackFreeze):
 
         super().__init__(*args, des_file=des_file, **kwargs)
 
-        
+
 class MiniHackFreezeWandRestrictedActions(MiniHackFreeze):
     def __init__(self, *args, **kwargs):
         lvl_gen = LevelGenerator(w=8, h=8, lit=True)
         lvl_gen.add_object("cold", "/", cursestate="blessed")
         des_file = lvl_gen.get_des()
 
-        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
-                                                     nethack.Command.ZAP, \
-                                                     nethack.Command.FIRE)
+        ACTIONS = tuple(nethack.CompassDirection) + (
+            nethack.Command.PICKUP,
+            nethack.Command.ZAP,
+            nethack.Command.FIRE,
+        )
         kwargs["actions"] = ACTIONS
-        
 
-        super().__init__(*args, des_file=des_file, **kwargs)        
+        super().__init__(*args, des_file=des_file, **kwargs)
 
 
 class MiniHackFreezeHorn(MiniHackFreeze):
@@ -57,14 +58,14 @@ class MiniHackFreezeHornRestrictedActions(MiniHackFreeze):
         lvl_gen.add_object("frost horn", "(", cursestate="blessed")
         des_file = lvl_gen.get_des()
 
-        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
-                                                     nethack.Command.APPLY, \
-                                                     nethack.Command.FIRE)
+        ACTIONS = tuple(nethack.CompassDirection) + (
+            nethack.Command.PICKUP,
+            nethack.Command.APPLY,
+            nethack.Command.FIRE,
+        )
         kwargs["actions"] = ACTIONS
-        
 
         super().__init__(*args, des_file=des_file, **kwargs)
-        
 
 
 class MiniHackFreezeRandom(MiniHackFreeze):
@@ -121,15 +122,15 @@ IF [50%] {
 }
 """
 
-        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
-                                                     nethack.Command.ZAP, \
-                                                     nethack.Command.APPLY, \
-                                                     nethack.Command.FIRE)
+        ACTIONS = tuple(nethack.CompassDirection) + (
+            nethack.Command.PICKUP,
+            nethack.Command.ZAP,
+            nethack.Command.APPLY,
+            nethack.Command.FIRE,
+        )
         kwargs["actions"] = ACTIONS
 
-        
         super().__init__(*args, des_file=des_file, **kwargs)
-        
 
 
 class MiniHackFreezeLava(MiniHackSkill):
@@ -193,15 +194,15 @@ IF [50%] {
 BRANCH:(1,1,5,5),(0,0,0,0)
 STAIR:rndcoord($right_bank),down
 """
-        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
-                                                     nethack.Command.ZAP, \
-                                                     nethack.Command.APPLY, \
-                                                     nethack.Command.FIRE)
+        ACTIONS = tuple(nethack.CompassDirection) + (
+            nethack.Command.PICKUP,
+            nethack.Command.ZAP,
+            nethack.Command.APPLY,
+            nethack.Command.FIRE,
+        )
         kwargs["actions"] = ACTIONS
 
-        
         super().__init__(*args, des_file=des_file, **kwargs)
-        
 
 
 register(

--- a/minihack/envs/skills_lava.py
+++ b/minihack/envs/skills_lava.py
@@ -30,16 +30,18 @@ STAIR:rndcoord($right_bank),down
 """
         super().__init__(*args, des_file=des_file, **kwargs)
 
+
 class MiniHackLCLevitatePotionPickupRestrictedActions(MiniHackSkill):
     def __init__(self, *args, **kwargs):
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 400)
 
-        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
-                                                     nethack.Command.QUAFF, \
-                                                     nethack.Command.FIRE)
+        ACTIONS = tuple(nethack.CompassDirection) + (
+            nethack.Command.PICKUP,
+            nethack.Command.QUAFF,
+            nethack.Command.FIRE,
+        )
         kwargs["actions"] = ACTIONS
 
-        
         des_file = """
 MAZE: "mylevel", ' '
 FLAGS:hardfloor
@@ -62,7 +64,6 @@ BRANCH:(1,1,5,5),(0,0,0,0)
 STAIR:rndcoord($right_bank),down
 """
         super().__init__(*args, des_file=des_file, **kwargs)
-        
 
 
 class MiniHackLCLevitatePotionInv(MiniHackSkill):
@@ -97,11 +98,13 @@ class MiniHackLCLevitatePotionInvRestrictedActions(MiniHackSkill):
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 400)
         kwargs["autopickup"] = kwargs.pop("autopickup", True)
 
-        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
-                                                     nethack.Command.QUAFF, \
-                                                     nethack.Command.FIRE)
+        ACTIONS = tuple(nethack.CompassDirection) + (
+            nethack.Command.PICKUP,
+            nethack.Command.QUAFF,
+            nethack.Command.FIRE,
+        )
         kwargs["actions"] = ACTIONS
-        
+
         des_file = """
 MAZE: "mylevel", ' '
 FLAGS:hardfloor
@@ -123,7 +126,6 @@ BRANCH:(2,2,2,2),(0,0,0,0)
 STAIR:rndcoord($right_bank),down
 """
         super().__init__(*args, des_file=des_file, **kwargs)
-        
 
 
 class MiniHackLCLevitateRingPickup(MiniHackSkill):
@@ -157,13 +159,14 @@ class MiniHackLCLevitateRingPickupRestrictedActions(MiniHackSkill):
     def __init__(self, *args, **kwargs):
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 400)
 
-        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
-                                                     nethack.Command.PUTON, \
-                                                     nethack.Command.FIRE, \
-                                                     nethack.Command.READ)
+        ACTIONS = tuple(nethack.CompassDirection) + (
+            nethack.Command.PICKUP,
+            nethack.Command.PUTON,
+            nethack.Command.FIRE,
+            nethack.Command.READ,
+        )
         kwargs["actions"] = ACTIONS
 
-        
         des_file = """
 MAZE: "mylevel", ' '
 FLAGS:hardfloor
@@ -186,8 +189,6 @@ BRANCH:(1,1,5,5),(0,0,0,0)
 STAIR:rndcoord($right_bank),down
 """
         super().__init__(*args, des_file=des_file, **kwargs)
-
-        
 
 
 class MiniHackLCLevitateRingInv(MiniHackSkill):
@@ -222,12 +223,14 @@ class MiniHackLCLevitateRingInvRestrictedActions(MiniHackSkill):
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 400)
         kwargs["autopickup"] = kwargs.pop("autopickup", True)
 
-        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
-                                                     nethack.Command.PUTON, \
-                                                     nethack.Command.FIRE, \
-                                                     nethack.Command.READ)
+        ACTIONS = tuple(nethack.CompassDirection) + (
+            nethack.Command.PICKUP,
+            nethack.Command.PUTON,
+            nethack.Command.FIRE,
+            nethack.Command.READ,
+        )
         kwargs["actions"] = ACTIONS
-        
+
         des_file = """
 MAZE: "mylevel", ' '
 FLAGS:hardfloor
@@ -249,16 +252,12 @@ BRANCH:(2,2,2,2),(0,0,0,0)
 STAIR:rndcoord($right_bank),down
 """
         super().__init__(*args, des_file=des_file, **kwargs)
-        
 
 
-
-
-        
 class MiniHackLCLevitate(MiniHackSkill):
     def __init__(self, *args, **kwargs):
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 400)
-        
+
         des_file = """
 MAZE: "mylevel", ' '
 FLAGS:hardfloor
@@ -289,21 +288,22 @@ BRANCH:(1,1,5,5),(0,0,0,0)
 STAIR:rndcoord($right_bank),down
 """
         super().__init__(*args, des_file=des_file, **kwargs)
-
 
 
 class MiniHackLCLevitateRestrictedActions(MiniHackSkill):
     def __init__(self, *args, **kwargs):
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 400)
 
-        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
-                                                     nethack.Command.WEAR, \
-                                                     nethack.Command.QUAFF, \
-                                                     nethack.Command.PUTON, \
-                                                     nethack.Command.FIRE, \
-                                                     nethack.Command.READ)
-        kwargs["actions"] = ACTIONS        
-        
+        ACTIONS = tuple(nethack.CompassDirection) + (
+            nethack.Command.PICKUP,
+            nethack.Command.WEAR,
+            nethack.Command.QUAFF,
+            nethack.Command.PUTON,
+            nethack.Command.FIRE,
+            nethack.Command.READ,
+        )
+        kwargs["actions"] = ACTIONS
+
         des_file = """
 MAZE: "mylevel", ' '
 FLAGS:hardfloor
@@ -334,7 +334,6 @@ BRANCH:(1,1,5,5),(0,0,0,0)
 STAIR:rndcoord($right_bank),down
 """
         super().__init__(*args, des_file=des_file, **kwargs)
-        
 
 
 class MiniHackLC(MiniHackSkill):
@@ -344,18 +343,19 @@ class MiniHackLC(MiniHackSkill):
 
 class MiniHackLCRestrictedActions(MiniHackSkill):
     def __init__(self, *args, **kwargs):
-        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
-                                                     nethack.Command.ZAP, \
-                                                     nethack.Command.WEAR, \
-                                                     nethack.Command.APPLY, \
-                                                     nethack.Command.QUAFF, \
-                                                     nethack.Command.PUTON, \
-                                                     nethack.Command.FIRE, \
-                                                     nethack.Command.READ)
-        kwargs["actions"] = ACTIONS        
-        
+        ACTIONS = tuple(nethack.CompassDirection) + (
+            nethack.Command.PICKUP,
+            nethack.Command.ZAP,
+            nethack.Command.WEAR,
+            nethack.Command.APPLY,
+            nethack.Command.QUAFF,
+            nethack.Command.PUTON,
+            nethack.Command.FIRE,
+            nethack.Command.READ,
+        )
+        kwargs["actions"] = ACTIONS
+
         super().__init__(*args, des_file="lava_crossing.des", **kwargs)
-        
 
 
 register(

--- a/minihack/envs/skills_lava.py
+++ b/minihack/envs/skills_lava.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackSkill
 from minihack.envs import register
+from nle import nethack
 
 
 class MiniHackLCLevitatePotionPickup(MiniHackSkill):
@@ -28,6 +29,40 @@ BRANCH:(1,1,5,5),(0,0,0,0)
 STAIR:rndcoord($right_bank),down
 """
         super().__init__(*args, des_file=des_file, **kwargs)
+
+class MiniHackLCLevitatePotionPickupRestrictedActions(MiniHackSkill):
+    def __init__(self, *args, **kwargs):
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 400)
+
+        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
+                                                     nethack.Command.QUAFF, \
+                                                     nethack.Command.FIRE)
+        kwargs["actions"] = ACTIONS
+
+        
+        des_file = """
+MAZE: "mylevel", ' '
+FLAGS:hardfloor
+INIT_MAP: solidfill,' '
+GEOMETRY:center,center
+MAP
+-------------
+|.....L.....|
+|.....L.....|
+|.....L.....|
+|.....L.....|
+|.....L.....|
+-------------
+ENDMAP
+REGION:(0,0,12,6),lit,"ordinary"
+$left_bank = selection:fillrect (1,1,5,5)
+$right_bank = selection:fillrect (7,1,11,5)
+OBJECT:('!',"levitation"),rndcoord($left_bank),blessed
+BRANCH:(1,1,5,5),(0,0,0,0)
+STAIR:rndcoord($right_bank),down
+"""
+        super().__init__(*args, des_file=des_file, **kwargs)
+        
 
 
 class MiniHackLCLevitatePotionInv(MiniHackSkill):
@@ -57,6 +92,40 @@ STAIR:rndcoord($right_bank),down
         super().__init__(*args, des_file=des_file, **kwargs)
 
 
+class MiniHackLCLevitatePotionInvRestrictedActions(MiniHackSkill):
+    def __init__(self, *args, **kwargs):
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 400)
+        kwargs["autopickup"] = kwargs.pop("autopickup", True)
+
+        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
+                                                     nethack.Command.QUAFF, \
+                                                     nethack.Command.FIRE)
+        kwargs["actions"] = ACTIONS
+        
+        des_file = """
+MAZE: "mylevel", ' '
+FLAGS:hardfloor
+INIT_MAP: solidfill,' '
+GEOMETRY:center,center
+MAP
+-------------
+|.....L.....|
+|.....L.....|
+|.....L.....|
+|.....L.....|
+|.....L.....|
+-------------
+ENDMAP
+REGION:(0,0,12,6),lit,"ordinary"
+$right_bank = selection:fillrect (7,1,11,5)
+OBJECT:('!',"levitation"),(2,2),blessed
+BRANCH:(2,2,2,2),(0,0,0,0)
+STAIR:rndcoord($right_bank),down
+"""
+        super().__init__(*args, des_file=des_file, **kwargs)
+        
+
+
 class MiniHackLCLevitateRingPickup(MiniHackSkill):
     def __init__(self, *args, **kwargs):
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 400)
@@ -82,6 +151,43 @@ BRANCH:(1,1,5,5),(0,0,0,0)
 STAIR:rndcoord($right_bank),down
 """
         super().__init__(*args, des_file=des_file, **kwargs)
+
+
+class MiniHackLCLevitateRingPickupRestrictedActions(MiniHackSkill):
+    def __init__(self, *args, **kwargs):
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 400)
+
+        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
+                                                     nethack.Command.PUTON, \
+                                                     nethack.Command.FIRE, \
+                                                     nethack.Command.READ)
+        kwargs["actions"] = ACTIONS
+
+        
+        des_file = """
+MAZE: "mylevel", ' '
+FLAGS:hardfloor
+INIT_MAP: solidfill,' '
+GEOMETRY:center,center
+MAP
+-------------
+|.....L.....|
+|.....L.....|
+|.....L.....|
+|.....L.....|
+|.....L.....|
+-------------
+ENDMAP
+REGION:(0,0,12,6),lit,"ordinary"
+$left_bank = selection:fillrect (1,1,5,5)
+$right_bank = selection:fillrect (7,1,11,5)
+OBJECT:('=',"levitation"),rndcoord($left_bank),blessed
+BRANCH:(1,1,5,5),(0,0,0,0)
+STAIR:rndcoord($right_bank),down
+"""
+        super().__init__(*args, des_file=des_file, **kwargs)
+
+        
 
 
 class MiniHackLCLevitateRingInv(MiniHackSkill):
@@ -111,9 +217,48 @@ STAIR:rndcoord($right_bank),down
         super().__init__(*args, des_file=des_file, **kwargs)
 
 
+class MiniHackLCLevitateRingInvRestrictedActions(MiniHackSkill):
+    def __init__(self, *args, **kwargs):
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 400)
+        kwargs["autopickup"] = kwargs.pop("autopickup", True)
+
+        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
+                                                     nethack.Command.PUTON, \
+                                                     nethack.Command.FIRE, \
+                                                     nethack.Command.READ)
+        kwargs["actions"] = ACTIONS
+        
+        des_file = """
+MAZE: "mylevel", ' '
+FLAGS:hardfloor
+INIT_MAP: solidfill,' '
+GEOMETRY:center,center
+MAP
+-------------
+|.....L.....|
+|.....L.....|
+|.....L.....|
+|.....L.....|
+|.....L.....|
+-------------
+ENDMAP
+REGION:(0,0,12,6),lit,"ordinary"
+$right_bank = selection:fillrect (7,1,11,5)
+OBJECT:('=',"levitation"),(2,2),blessed
+BRANCH:(2,2,2,2),(0,0,0,0)
+STAIR:rndcoord($right_bank),down
+"""
+        super().__init__(*args, des_file=des_file, **kwargs)
+        
+
+
+
+
+        
 class MiniHackLCLevitate(MiniHackSkill):
     def __init__(self, *args, **kwargs):
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 400)
+        
         des_file = """
 MAZE: "mylevel", ' '
 FLAGS:hardfloor
@@ -146,32 +291,118 @@ STAIR:rndcoord($right_bank),down
         super().__init__(*args, des_file=des_file, **kwargs)
 
 
+
+class MiniHackLCLevitateRestrictedActions(MiniHackSkill):
+    def __init__(self, *args, **kwargs):
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 400)
+
+        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
+                                                     nethack.Command.WEAR, \
+                                                     nethack.Command.QUAFF, \
+                                                     nethack.Command.PUTON, \
+                                                     nethack.Command.FIRE, \
+                                                     nethack.Command.READ)
+        kwargs["actions"] = ACTIONS        
+        
+        des_file = """
+MAZE: "mylevel", ' '
+FLAGS:hardfloor
+INIT_MAP: solidfill,' '
+GEOMETRY:center,center
+MAP
+-------------
+|.....L.....|
+|.....L.....|
+|.....L.....|
+|.....L.....|
+|.....L.....|
+-------------
+ENDMAP
+REGION:(0,0,12,6),lit,"ordinary"
+$left_bank = selection:fillrect (1,1,5,5)
+$right_bank = selection:fillrect (7,1,11,5)
+IF [33%] {
+    OBJECT:('!',"levitation"),rndcoord($left_bank),blessed
+} ELSE {
+    IF [50%] {
+        OBJECT:('=',"levitation"),rndcoord($left_bank),blessed
+    } ELSE {
+        OBJECT:('[',"levitation boots"),rndcoord($left_bank),blessed
+    }
+}
+BRANCH:(1,1,5,5),(0,0,0,0)
+STAIR:rndcoord($right_bank),down
+"""
+        super().__init__(*args, des_file=des_file, **kwargs)
+        
+
+
 class MiniHackLC(MiniHackSkill):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, des_file="lava_crossing.des", **kwargs)
 
 
+class MiniHackLCRestrictedActions(MiniHackSkill):
+    def __init__(self, *args, **kwargs):
+        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
+                                                     nethack.Command.ZAP, \
+                                                     nethack.Command.WEAR, \
+                                                     nethack.Command.APPLY, \
+                                                     nethack.Command.QUAFF, \
+                                                     nethack.Command.PUTON, \
+                                                     nethack.Command.FIRE, \
+                                                     nethack.Command.READ)
+        kwargs["actions"] = ACTIONS        
+        
+        super().__init__(*args, des_file="lava_crossing.des", **kwargs)
+        
+
+
 register(
-    id="MiniHack-LavaCross-Levitate-Potion-Pickup-v0",
+    id="MiniHack-LavaCross-Levitate-Potion-Pickup-Full-v0",
     entry_point="minihack.envs.skills_lava:MiniHackLCLevitatePotionPickup",
 )
 register(
-    id="MiniHack-LavaCross-Levitate-Potion-Inv-v0",
+    id="MiniHack-LavaCross-Levitate-Potion-Pickup-Restricted-v0",
+    entry_point="minihack.envs.skills_lava:MiniHackLCLevitatePotionPickupRestrictedActions",
+)
+register(
+    id="MiniHack-LavaCross-Levitate-Potion-Inv-Full-v0",
     entry_point="minihack.envs.skills_lava:MiniHackLCLevitatePotionInv",
 )
 register(
-    id="MiniHack-LavaCross-Levitate-Ring-Pickup-v0",
+    id="MiniHack-LavaCross-Levitate-Potion-Inv-Restricted-v0",
+    entry_point="minihack.envs.skills_lava:MiniHackLCLevitatePotionInvRestrictedActions",
+)
+register(
+    id="MiniHack-LavaCross-Levitate-Ring-Pickup-Full-v0",
     entry_point="minihack.envs.skills_lava:MiniHackLCLevitateRingPickup",
 )
 register(
-    id="MiniHack-LavaCross-Levitate-Ring-Inv-v0",
+    id="MiniHack-LavaCross-Levitate-Ring-Pickup-Restricted-v0",
+    entry_point="minihack.envs.skills_lava:MiniHackLCLevitateRingPickupRestrictedActions",
+)
+register(
+    id="MiniHack-LavaCross-Levitate-Ring-Inv-Full-v0",
     entry_point="minihack.envs.skills_lava:MiniHackLCLevitateRingInv",
 )
 register(
-    id="MiniHack-LavaCross-Levitate-v0",
+    id="MiniHack-LavaCross-Levitate-Ring-Inv-Restricted-v0",
+    entry_point="minihack.envs.skills_lava:MiniHackLCLevitateRingInvRestrictedActions",
+)
+register(
+    id="MiniHack-LavaCross-Levitate-Full-v0",
     entry_point="minihack.envs.skills_lava:MiniHackLCLevitate",
 )
 register(
-    id="MiniHack-LavaCross-v0",
+    id="MiniHack-LavaCross-Levitate-Restricted-v0",
+    entry_point="minihack.envs.skills_lava:MiniHackLCLevitateRestrictedActions",
+)
+register(
+    id="MiniHack-LavaCross-Full-v0",
     entry_point="minihack.envs.skills_lava:MiniHackLC",
+)
+register(
+    id="MiniHack-LavaCross-Restricted-v0",
+    entry_point="minihack.envs.skills_lava:MiniHackLCRestrictedActions",
 )

--- a/minihack/envs/skills_levitate.py
+++ b/minihack/envs/skills_levitate.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackSkill, LevelGenerator, RewardManager
 from minihack.envs import register
+from nle import nethack
 
 
 levitation_msg = [
@@ -43,6 +44,22 @@ class MiniHackLevitateBootsFixed(MiniHackLevitate):
         super().__init__(*args, des_file=des_file, **kwargs)
 
 
+class MiniHackLevitateBootsRestrictedActions(MiniHackLevitate):
+    def __init__(self, *args, **kwargs):
+        lvl_gen = LevelGenerator(w=5, h=5, lit=True)
+        lvl_gen.add_object("levitation boots", "[", cursestate="blessed")
+        des_file = lvl_gen.get_des()
+
+        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
+                                                     nethack.Command.WEAR, \
+                                                     nethack.Command.FIRE)
+        kwargs["actions"] = ACTIONS
+        
+
+        super().__init__(*args, des_file=des_file, **kwargs)
+        
+
+
 class MiniHackLevitateRing(MiniHackLevitate):
     def __init__(self, *args, **kwargs):
         lvl_gen = LevelGenerator(w=5, h=5, lit=True)
@@ -64,6 +81,21 @@ class MiniHackLevitateRingFixed(MiniHackLevitate):
         super().__init__(*args, des_file=des_file, **kwargs)
 
 
+class MiniHackLevitateRingRestrictedActions(MiniHackLevitate):
+    def __init__(self, *args, **kwargs):
+        lvl_gen = LevelGenerator(w=5, h=5, lit=True)
+        lvl_gen.add_object("levitation", "=", cursestate="blessed")
+        des_file = lvl_gen.get_des()
+
+        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
+                                                     nethack.Command.PUTON, \
+                                                     nethack.Command.FIRE, \
+                                                     nethack.Command.READ)
+        kwargs["actions"] = ACTIONS
+        
+        super().__init__(*args, des_file=des_file, **kwargs)        
+
+
 class MiniHackLevitatePotion(MiniHackLevitate):
     def __init__(self, *args, **kwargs):
         lvl_gen = LevelGenerator(w=5, h=5, lit=True)
@@ -83,6 +115,21 @@ class MiniHackLevitatePotionFixed(MiniHackLevitate):
         des_file = lvl_gen.get_des()
 
         super().__init__(*args, des_file=des_file, **kwargs)
+
+        
+class MiniHackLevitatePotionRestrictedActions(MiniHackLevitate):
+    def __init__(self, *args, **kwargs):
+        lvl_gen = LevelGenerator(w=5, h=5, lit=True)
+        lvl_gen.add_object("levitation", "!", cursestate="blessed")
+        des_file = lvl_gen.get_des()
+
+        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
+                                                     nethack.Command.QUAFF, \
+                                                     nethack.Command.FIRE)
+        kwargs["actions"] = ACTIONS
+        
+
+        super().__init__(*args, des_file=des_file, **kwargs)        
 
 
 class MiniHackLevitateRandom(MiniHackLevitate):
@@ -115,19 +162,31 @@ IF [33%] {
 
 
 register(
-    id="MiniHack-Levitate-Boots-v0",
+    id="MiniHack-Levitate-Boots-Full-v0",
     entry_point="minihack.envs.skills_levitate:MiniHackLevitateBoots",
 )
 register(
-    id="MiniHack-Levitate-Ring-v0",
+    id="MiniHack-Levitate-Boots-Restricted-v0",
+    entry_point="minihack.envs.skills_levitate:MiniHackLevitateBootsRestrictedActions",
+)
+register(
+    id="MiniHack-Levitate-Ring-Full-v0",
     entry_point="minihack.envs.skills_levitate:MiniHackLevitateRing",
 )
 register(
-    id="MiniHack-Levitate-Potion-v0",
+    id="MiniHack-Levitate-Ring-Restricted-v0",
+    entry_point="minihack.envs.skills_levitate:MiniHackLevitateRingRestrictedActions",
+)
+register(
+    id="MiniHack-Levitate-Potion-Full-v0",
     entry_point="minihack.envs.skills_levitate:MiniHackLevitatePotion",
 )
 register(
-    id="MiniHack-Levitate-Random-v0",
+    id="MiniHack-Levitate-Potion-Restricted-v0",
+    entry_point="minihack.envs.skills_levitate:MiniHackLevitatePotionRestrictedActions",
+)
+register(
+    id="MiniHack-Levitate-Random-Full-v0",
     entry_point="minihack.envs.skills_levitate:MiniHackLevitateRandom",
 )
 register(

--- a/minihack/envs/skills_levitate.py
+++ b/minihack/envs/skills_levitate.py
@@ -50,14 +50,14 @@ class MiniHackLevitateBootsRestrictedActions(MiniHackLevitate):
         lvl_gen.add_object("levitation boots", "[", cursestate="blessed")
         des_file = lvl_gen.get_des()
 
-        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
-                                                     nethack.Command.WEAR, \
-                                                     nethack.Command.FIRE)
+        ACTIONS = tuple(nethack.CompassDirection) + (
+            nethack.Command.PICKUP,
+            nethack.Command.WEAR,
+            nethack.Command.FIRE,
+        )
         kwargs["actions"] = ACTIONS
-        
 
         super().__init__(*args, des_file=des_file, **kwargs)
-        
 
 
 class MiniHackLevitateRing(MiniHackLevitate):
@@ -87,13 +87,15 @@ class MiniHackLevitateRingRestrictedActions(MiniHackLevitate):
         lvl_gen.add_object("levitation", "=", cursestate="blessed")
         des_file = lvl_gen.get_des()
 
-        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
-                                                     nethack.Command.PUTON, \
-                                                     nethack.Command.FIRE, \
-                                                     nethack.Command.READ)
+        ACTIONS = tuple(nethack.CompassDirection) + (
+            nethack.Command.PICKUP,
+            nethack.Command.PUTON,
+            nethack.Command.FIRE,
+            nethack.Command.READ,
+        )
         kwargs["actions"] = ACTIONS
-        
-        super().__init__(*args, des_file=des_file, **kwargs)        
+
+        super().__init__(*args, des_file=des_file, **kwargs)
 
 
 class MiniHackLevitatePotion(MiniHackLevitate):
@@ -116,20 +118,21 @@ class MiniHackLevitatePotionFixed(MiniHackLevitate):
 
         super().__init__(*args, des_file=des_file, **kwargs)
 
-        
+
 class MiniHackLevitatePotionRestrictedActions(MiniHackLevitate):
     def __init__(self, *args, **kwargs):
         lvl_gen = LevelGenerator(w=5, h=5, lit=True)
         lvl_gen.add_object("levitation", "!", cursestate="blessed")
         des_file = lvl_gen.get_des()
 
-        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
-                                                     nethack.Command.QUAFF, \
-                                                     nethack.Command.FIRE)
+        ACTIONS = tuple(nethack.CompassDirection) + (
+            nethack.Command.PICKUP,
+            nethack.Command.QUAFF,
+            nethack.Command.FIRE,
+        )
         kwargs["actions"] = ACTIONS
-        
 
-        super().__init__(*args, des_file=des_file, **kwargs)        
+        super().__init__(*args, des_file=des_file, **kwargs)
 
 
 class MiniHackLevitateRandom(MiniHackLevitate):

--- a/minihack/envs/skills_wod.py
+++ b/minihack/envs/skills_wod.py
@@ -59,16 +59,16 @@ class MiniHackWoDEasyRestrictedActions(MiniHackSkill):
         rwrd_mngr = RewardManager()
         rwrd_mngr.add_kill_event("minotaur")
 
-        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
-                                                     nethack.Command.ZAP, \
-                                                     nethack.Command.FIRE)
+        ACTIONS = tuple(nethack.CompassDirection) + (
+            nethack.Command.PICKUP,
+            nethack.Command.ZAP,
+            nethack.Command.FIRE,
+        )
         kwargs["actions"] = ACTIONS
-        
 
         super().__init__(
             *args, des_file=des_file, reward_manager=rwrd_mngr, **kwargs
         )
-        
 
 
 class MiniHackWoDMedium(MiniHackSkill):
@@ -111,16 +111,15 @@ class MiniHackWoDMediumRestrictedActions(MiniHackSkill):
         lvl_gen.add_monster("minotaur", args=("asleep",), place=(26, 1))
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 150)
 
-        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
-                                                     nethack.Command.ZAP, \
-                                                     nethack.Command.FIRE)
+        ACTIONS = tuple(nethack.CompassDirection) + (
+            nethack.Command.PICKUP,
+            nethack.Command.ZAP,
+            nethack.Command.FIRE,
+        )
         kwargs["actions"] = ACTIONS
-        
-        
 
         des_file = lvl_gen.get_des()
         super().__init__(*args, des_file=des_file, **kwargs)
-        
 
 
 class MiniHackWoDHard(MiniHackSkill):
@@ -172,14 +171,14 @@ class MiniHackWoDHardRestrictedActions(MiniHackSkill):
         des_file = lvl_gen.get_des()
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 400)
 
-        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
-                                                     nethack.Command.ZAP, \
-                                                     nethack.Command.FIRE)
+        ACTIONS = tuple(nethack.CompassDirection) + (
+            nethack.Command.PICKUP,
+            nethack.Command.ZAP,
+            nethack.Command.FIRE,
+        )
         kwargs["actions"] = ACTIONS
-        
 
         super().__init__(*args, des_file=des_file, **kwargs)
-        
 
 
 class MiniHackWoDPro(MiniHackSkill):
@@ -255,18 +254,18 @@ class MiniHackWoDProRestrictedActions(MiniHackSkill):
         des_file = lvl_gen.get_des()
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 1000)
 
-        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
-                                                     nethack.Command.ZAP, \
-                                                     nethack.Command.FIRE)
+        ACTIONS = tuple(nethack.CompassDirection) + (
+            nethack.Command.PICKUP,
+            nethack.Command.ZAP,
+            nethack.Command.FIRE,
+        )
         kwargs["actions"] = ACTIONS
-        
 
         super().__init__(
             *args,
             des_file=des_file,
             **kwargs,
         )
-        
 
 
 register(

--- a/minihack/envs/skills_wod.py
+++ b/minihack/envs/skills_wod.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from minihack import MiniHackSkill, LevelGenerator, RewardManager
 from minihack.envs import register
+from nle import nethack
 
 
 class MiniHackWoDEasy(MiniHackSkill):
@@ -33,6 +34,43 @@ class MiniHackWoDEasy(MiniHackSkill):
         )
 
 
+class MiniHackWoDEasyRestrictedActions(MiniHackSkill):
+    """Environment for "Wand of death" task."""
+
+    def __init__(self, *args, **kwargs):
+        map = """
+|----------
+|.........+
+|----------
+"""
+        lvl_gen = LevelGenerator(map=map, lit=True)
+
+        lvl_gen.set_start_pos((1, 1))
+        kwargs["autopickup"] = kwargs.pop("autopickup", True)
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 50)
+
+        lvl_gen.add_object(
+            name="death", symbol="/", cursestate="blessed", place=((1, 1))
+        )
+        lvl_gen.add_monster("minotaur", args=("asleep",), place=(9, 1))
+
+        des_file = lvl_gen.get_des()
+
+        rwrd_mngr = RewardManager()
+        rwrd_mngr.add_kill_event("minotaur")
+
+        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
+                                                     nethack.Command.ZAP, \
+                                                     nethack.Command.FIRE)
+        kwargs["actions"] = ACTIONS
+        
+
+        super().__init__(
+            *args, des_file=des_file, reward_manager=rwrd_mngr, **kwargs
+        )
+        
+
+
 class MiniHackWoDMedium(MiniHackSkill):
     def __init__(self, *args, **kwargs):
         map = """
@@ -53,6 +91,36 @@ class MiniHackWoDMedium(MiniHackSkill):
 
         des_file = lvl_gen.get_des()
         super().__init__(*args, des_file=des_file, **kwargs)
+
+
+class MiniHackWoDMediumRestrictedActions(MiniHackSkill):
+    def __init__(self, *args, **kwargs):
+        map = """
+|---------------------------|
+|...........................|
+|---------------------------|
+"""
+        lvl_gen = LevelGenerator(map=map, lit=True)
+
+        lvl_gen.set_start_pos((1, 1))
+        lvl_gen.add_goal_pos((27, 1))
+
+        lvl_gen.add_object(
+            name="death", symbol="/", cursestate="blessed", place=((2, 1))
+        )
+        lvl_gen.add_monster("minotaur", args=("asleep",), place=(26, 1))
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 150)
+
+        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
+                                                     nethack.Command.ZAP, \
+                                                     nethack.Command.FIRE)
+        kwargs["actions"] = ACTIONS
+        
+        
+
+        des_file = lvl_gen.get_des()
+        super().__init__(*args, des_file=des_file, **kwargs)
+        
 
 
 class MiniHackWoDHard(MiniHackSkill):
@@ -79,6 +147,39 @@ class MiniHackWoDHard(MiniHackSkill):
         kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 400)
 
         super().__init__(*args, des_file=des_file, **kwargs)
+
+
+class MiniHackWoDHardRestrictedActions(MiniHackSkill):
+    def __init__(self, *args, **kwargs):
+        map = """
+|---------------------------|
+|...........................|
+|.....|---------------------|
+|.....|
+|.....|
+|-----|
+"""
+        lvl_gen = LevelGenerator(map=map, lit=True)
+
+        lvl_gen.set_start_rect((1, 1), (5, 5))
+        lvl_gen.add_goal_pos((27, 1))
+
+        lvl_gen.set_area_variable("$safe_room", "fillrect", 1, 1, 5, 5)
+        lvl_gen.add_object_area(
+            "$safe_room", name="death", symbol="/", cursestate="blessed"
+        )
+        lvl_gen.add_monster("minotaur", place=(26, 1))
+        des_file = lvl_gen.get_des()
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 400)
+
+        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
+                                                     nethack.Command.ZAP, \
+                                                     nethack.Command.FIRE)
+        kwargs["actions"] = ACTIONS
+        
+
+        super().__init__(*args, des_file=des_file, **kwargs)
+        
 
 
 class MiniHackWoDPro(MiniHackSkill):
@@ -121,20 +222,82 @@ class MiniHackWoDPro(MiniHackSkill):
         )
 
 
-register(
-    id="MiniHack-WoD-Easy-v0",
-    entry_point="minihack.envs.skills_wod:MiniHackWoDEasy",
-)
+class MiniHackWoDProRestrictedActions(MiniHackSkill):
+    def __init__(self, *args, **kwargs):
+        map = """
+-------------------------------------
+|.................|.|...............|
+|.|-------------|.|.|.------------|.|
+|.|.............|.|.|.............|.|
+|.|.|----------.|.|.|------------.|.|
+|.|.|...........|.|.............|.|.|
+|.|.|.|----------.|-----------|.|.|.|
+|.|.|.|...........|.......|...|.|.|.|
+|.|.|.|.|----------------.|.|.|.|.|.|
+|.|.|.|.|.................|.|.|.|.|.|
+|.|.|.|.|.-----------------.|.|.|.|.|
+|.|.|.|.|...................|.|.|.|.|
+|.|.|.|.|--------------------.|.|.|.|
+|.|.|.|.......................|.|.|.|
+|.|.|.|-----------------------|.|.|.|
+|.|.|...........................|.|.|
+|.|.|---------------------------|.|.|
+|.|...............................|.|
+|.|-------------------------------|.|
+|...................................|
+-------------------------------------
+"""
+        lvl_gen = LevelGenerator(map=map, lit=True)
+        lvl_gen.set_start_pos((19, 1))
+        lvl_gen.add_goal_pos((19, 7))
+        lvl_gen.add_monster(name="minotaur", place=(19, 9))
+        lvl_gen.add_object("death", "/", cursestate="blessed")
+        des_file = lvl_gen.get_des()
+        kwargs["max_episode_steps"] = kwargs.pop("max_episode_steps", 1000)
+
+        ACTIONS = tuple(nethack.CompassDirection) + (nethack.Command.PICKUP, \
+                                                     nethack.Command.ZAP, \
+                                                     nethack.Command.FIRE)
+        kwargs["actions"] = ACTIONS
+        
+
+        super().__init__(
+            *args,
+            des_file=des_file,
+            **kwargs,
+        )
+        
+
 
 register(
-    id="MiniHack-WoD-Medium-v0",
+    id="MiniHack-WoD-Easy-Full-v0",
+    entry_point="minihack.envs.skills_wod:MiniHackWoDEasy",
+)
+register(
+    id="MiniHack-WoD-Easy-Restricted-v0",
+    entry_point="minihack.envs.skills_wod:MiniHackWoDEasyRestrictedActions",
+)
+register(
+    id="MiniHack-WoD-Medium-Full-v0",
     entry_point="minihack.envs.skills_wod:MiniHackWoDMedium",
 )
 register(
-    id="MiniHack-WoD-Hard-v0",
+    id="MiniHack-WoD-Medium-Restricted-v0",
+    entry_point="minihack.envs.skills_wod:MiniHackWoDMediumRestrictedActions",
+)
+register(
+    id="MiniHack-WoD-Hard-Full-v0",
     entry_point="minihack.envs.skills_wod:MiniHackWoDHard",
 )
 register(
-    id="MiniHack-WoD-Pro-v0",
+    id="MiniHack-WoD-Hard-Restricted-v0",
+    entry_point="minihack.envs.skills_wod:MiniHackWoDHardRestrictedActions",
+)
+register(
+    id="MiniHack-WoD-Pro-Full-v0",
     entry_point="minihack.envs.skills_wod:MiniHackWoDPro",
+)
+register(
+    id="MiniHack-WoD-Pro-Restricted-v0",
+    entry_point="minihack.envs.skills_wod:MiniHackWoDProRestrictedActions",
 )


### PR DESCRIPTION
This includes:

- adding N10 versions of MiniGrid envs
- adding versions with open doors, lava, monsters
- adding versions of skill-based tasks with restricted action spaces. The original versions with the full action space are marked by `X-Full-v0` and the ones with the restricted action spaces are marked with `X-Restricted-v0`