### PR TITLE
Fixing flake8 repo link in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     - id: black
       language_version: python3.8
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: '3.8.4'
     hooks:
     - id: flake8


### PR DESCRIPTION
Flake8 has been moved from gitlab to github.

Closes #70 