### PR TITLE
 Configuring the action space of MiniHack following NLE updates

### DIFF
--- a/minihack/base.py
+++ b/minihack/base.py
@@ -26,8 +26,7 @@ try:
     MH_FULL_ACTIONS.remove(nethack.MiscDirection.UP)
 except ValueError:
     pass
-NLE_VERSION = pkg_resources.get_distribution("nle").version[:5]
-if NLE_VERSION in ["0.8.1", "0.9.0"]:
+try:
     NLE_EXTRA_V081_ACTIONS = (
         nethack.Command.SEEARMOR,
         nethack.Command.SEERINGS,
@@ -37,7 +36,7 @@ if NLE_VERSION in ["0.8.1", "0.9.0"]:
         nethack.TextCharacters.PLUS,
         nethack.TextCharacters.QUOTE,
     )
-else:
+except AttributeError:
     NLE_EXTRA_V081_ACTIONS = ()
 HACKDIR = pkg_resources.resource_filename("nle", "nethackdir")
 
@@ -151,7 +150,7 @@ class MiniHack(NetHackStaircase):
         pet=False,
         observation_keys=MH_DEFAULT_OBS_KEYS,
         seeds=None,
-        include_see_actions=False,
+        include_see_actions=True,
         **kwargs,
     ):
         """Constructs a new MiniHack environment.


### PR DESCRIPTION
[NLE 0.8.1 release added additional actions](https://github.com/facebookresearch/nle/commit/314d804d0bb636e8e2d43649ce4174fe9d2753d0#diff-c38a2e3d7fd00da829168d0dcf91b020b6fefcd10a37156a69b287bbca2f7c87) which MiniHack inherited. This PR is making sure that models trained on the prior versions of nle can be used on recent minihack versions.

To this end, we introduce a new argument include_see_actions  in the base class of MiniHack. When set to True, the agent's action space includes the additional NLE actions introduced in the 0.8.1 release. Has no effect when the actions parameter is specified or if the installed nle version is < 0.8.1. Defaults to True.