### PR TITLE
Fixing the access to environments actions after NLE==0.9.0 update

### DIFF
--- a/minihack/agent/common/envs/wrapper.py
+++ b/minihack/agent/common/envs/wrapper.py
@@ -68,7 +68,7 @@ class CropWrapper(gym.Wrapper):
         assert self.h % 2 == 1
         assert self.w % 2 == 1
         self.last_observation = None
-        self._actions = self.env._actions
+        self._actions = self.env.actions
 
     def render(self, mode="human", crop=True):
         self.env.render()
@@ -119,7 +119,7 @@ class PrevWrapper(gym.Wrapper):
         super().__init__(env)
         self.env = env
         self.last_observation = None
-        self._actions = self.env._actions
+        self._actions = self.env.actions
 
     def step(self, action):
         next_state, reward, done, info = self.env.step(action)

--- a/minihack/agent/polybeast/evaluate.py
+++ b/minihack/agent/polybeast/evaluate.py
@@ -82,7 +82,7 @@ def eval(
     if seeds is not None:
         env.seed(seeds)
     if not no_render:
-        print("Available actions:", env._actions)
+        print("Available actions:", env.actions)
 
     obs = env.reset()
     done = False
@@ -117,7 +117,7 @@ def eval(
         if watch and not no_render:
             print("Previous reward:", reward)
             if action is not None:
-                print("Previous action: %s" % repr(env._actions[action]))
+                print("Previous action: %s" % repr(env.actions[action]))
             env.render(render_mode)
 
         if save_gif:

--- a/minihack/reward_manager.py
+++ b/minihack/reward_manager.py
@@ -138,11 +138,11 @@ class LocActionEvent(Event):
 
     def check(self, env, previous_observation, action, observation) -> float:
         del previous_observation, observation
-        if env._actions[action] == self.action and _standing_on_top(
+        if env.actions[action] == self.action and _standing_on_top(
             env, self.loc
         ):
             self.status = True
-        elif env._actions[action] == Y_cmd and self.status:
+        elif env.actions[action] == Y_cmd and self.status:
             return self._set_achieved()
         else:
             self.status = False

--- a/minihack/tiles/rendering.py
+++ b/minihack/tiles/rendering.py
@@ -59,7 +59,7 @@ def get_des_file_rendering(
             for c in f"q{msg[0]}":
                 obs, sds = env.env.step(ord(c))
 
-            obs, _, _, _ = env.step(env._actions.index(MiscDirection.WAIT))
+            obs, _, _, _ = env.step(env.actions.index(MiscDirection.WAIT))
         return obs
 
     env = MHCustom(


### PR DESCRIPTION
`env._actions` has been renamed to `env.actions` in the new version of NLE. Applying the same changes on the MiniHack side following @ngoodger's recommendation.
 
Closes #82 
