### PR TITLE
Fixing MiniHacks obs space if include_alignment_blstats==False

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
         os: [ubuntu-latest, macos-latest]
       fail-fast: false
     steps:

--- a/minihack/base.py
+++ b/minihack/base.py
@@ -328,18 +328,18 @@ class MiniHack(NetHackStaircase):
     def _get_obs_space_dict(self, space_dict):
         obs_space_dict = {}
         for key in self._minihack_obs_keys:
-            if key in space_dict.keys():
-                obs_space_dict[key] = space_dict[key]
-            elif "blstats" in key and self.remove_alignment_blstats:
+            if "blstats" in key and self.remove_alignment_blstats:
                 # Remove alignment from blstats to make minihack compatible
                 # with NLE version v0.8.1
-                obs_space_dict[key] = (
-                    gym.spaces.Box(
-                        low=np.iinfo(np.int32).min,
-                        high=np.iinfo(np.int32).max,
-                        **nethack.OBSERVATION_DESC["blstats"] - 1,
-                    ),
+                shape = nethack.OBSERVATION_DESC["blstats"]["shape"]
+                obs_space_dict[key] = gym.spaces.Box(
+                    low=np.iinfo(np.int32).min,
+                    high=np.iinfo(np.int32).max,
+                    shape=(shape[0] - 1,),
+                    dtype=nethack.OBSERVATION_DESC["blstats"]["dtype"],
                 )
+            elif key in space_dict.keys():
+                obs_space_dict[key] = space_dict[key]
             elif key in MINIHACK_SPACE_FUNCS.keys():
                 space_func = MINIHACK_SPACE_FUNCS[key]
                 obs_space_dict[key] = space_func(

--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,6 @@ if __name__ == "__main__":
             "Operating System :: POSIX :: Linux",
             "Operating System :: MacOS",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
`observation_space` was being computed incorrectly when `include_alignment_blstats=False` was being passed to MiniHack environments, introduced in #77.

This PR makes sure that the `observation_space` is computed accurately. 

```python
>>> import gym, minihack
>>> env = gym.make("MiniHack-MultiRoom-N6-v0", include_alignment_blstats=False)
>>> env.observation_space["blstats"]
Box(-2147483648, 2147483647, (26,), int64)
>>> env = gym.make("MiniHack-MultiRoom-N6-v0", include_alignment_blstats=True)
>>> env.observation_space["blstats"]
Box(-2147483648, 2147483647, (27,), int64)
``` 