### PR TITLE
Fix MiniHack-MiniGrid environment size constraints

### DIFF
--- a/minihack/envs/minigrid.py
+++ b/minihack/envs/minigrid.py
@@ -81,12 +81,19 @@ class MiniGridHack(MiniHackNavigation):
         return env_map, start_pos, goal_pos, door_pos
 
     def get_env_desc(self):
-        self.minigrid_env.reset()
-        env = self.minigrid_env
+        i = 0
+        env_size = (100, 100)
+        # sometimes the env is too big, try to generate a smaller one
+        # some environments are initialized with size=25, example MultiRoom-N6
+        while (env_size[0] > 75 or env_size[1] > 20) and i < 10:
+            self.minigrid_env.reset()
+            env = self.minigrid_env
 
-        map, start_pos, goal_pos, door_pos = self.get_env_map(env)
+            map, start_pos, goal_pos, door_pos = self.get_env_map(env)
+            lev_gen = LevelGenerator(map=map)
 
-        lev_gen = LevelGenerator(map=map)
+            env_size = (lev_gen.x, lev_gen.y)
+            i += 1
 
         lev_gen.add_goal_pos(goal_pos)
         lev_gen.set_start_pos(start_pos)


### PR DESCRIPTION
### Overview
This PR addresses an issue with environment size handling in the MiniHack-MiniGrid integration. Some environments were being generated with dimensions too large for optimal performance, particularly affecting environments like MultiRoom-N6.

### Changes
- Added a size constraint loop that attempts to generate environments within reasonable bounds (max 77x21)
- Implements retry logic (max 10 attempts) to regenerate environments if they exceed size limits
- Preserves environment functionality while ensuring more consistent dimensions

### Testing
* [x] Verified functionality with MultiRoom-N6 environment
* [x] Confirmed environment generation stays within size constraints
* [x] Tested that environment behavior remains unchanged
* [x] Have you successfully ran tests with your changes locally?

### Notes
- I wrote the code in a way that wouldn't require changes in gym_minigrid. Unfortunately, there is no way to specify size of the map, because `MultiRoomEnv` has `self.size = 25` fixed. Only other option would be to upgrade to `minigrid` but this is based on gymnasium and would require additional changes to minihack and would probably break many things.