### PR TITLE
Disabling scheduled github actions

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -6,12 +6,8 @@ on:
     branches:
       - main
   pull_request:
-  schedule:
-    - cron: "0 6,18 * * *"
   release:
     types: [released]
-
-
 jobs:
   test_repo:
     name: Test on ${{ matrix.os }} w/ Py${{ matrix.python-version }}


### PR DESCRIPTION
Disabling routinely scheduled test_and_deploy github action. Keeping it enabled only for push to main, PRs, and releases.